### PR TITLE
Extended WKT, WKB, and GeoJson conversion support

### DIFF
--- a/GISBlox.Services.SDK/GISBlox.Services.SDK.Tests/ConversionTests.cs
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK.Tests/ConversionTests.cs
@@ -5,8 +5,7 @@ namespace GISBlox.Services.SDK.Tests
    {
       GISBloxClient _client;
       const string BASE_URL = "https://services-private.gisblox.com";
-
-      private const string WKB_POINT_30_10 = "AQEAAAAAAAAAAAA+QAAAAAAAACRA";
+            
       private static readonly byte[] WKB_POINT_30_10_BYTES = [ 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 62, 64, 0, 0, 0, 0, 0, 0, 36, 64 ];
       private static readonly byte[] WKB_POINT_30_10_5_BYTES = [1, 233, 3, 0, 0, 0, 0, 0, 0, 0, 0, 62, 64, 0, 0, 0, 0, 0, 0, 36, 64, 0, 0, 0, 0, 0, 0, 20, 64];
 
@@ -45,7 +44,7 @@ namespace GISBlox.Services.SDK.Tests
       [TestMethod]
       public async Task ConvertPoint_WKB()
       { 
-         WKB wkb = new(WKB_POINT_30_10_BYTES);
+         WKB wkb = new(WKB_POINT_30_10_5_BYTES);
          string geoJson = await ConvertToGeoJsonFromWKB(wkb);
 
          Assert.IsNotNull(geoJson, "Response is empty.");
@@ -65,9 +64,9 @@ namespace GISBlox.Services.SDK.Tests
       [TestMethod]
       public async Task ConvertMultiPoint_WKB()
       {
-         // TODO: Replace with actual WKB for MULTIPOINT ((1040), (40302), (2020), (3010))
-         byte[] wkbBytes = new byte[] { /* WKB bytes for MULTIPOINT ((1040), (40302), (2020), (3010)) */ };
-         WKB wkb = new(wkbBytes);
+         byte[] multiPoint = [1, 4, 0, 0, 0, 4, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 36, 64, 0, 0, 0, 0, 0, 0, 68, 64, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 68, 64, 0, 0, 0, 0, 0, 0, 62, 64, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 52, 64, 0, 0, 0, 0, 0, 0, 52, 64, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 62, 64, 0, 0, 0, 0, 0, 0, 36, 64];
+         WKB wkb = new(multiPoint);
+
          string geoJson = await ConvertToGeoJsonFromWKB(wkb);
 
          Assert.IsNotNull(geoJson, "Response is empty.");
@@ -77,7 +76,7 @@ namespace GISBlox.Services.SDK.Tests
       [TestMethod]
       public async Task ConvertLineString()
       {
-         WKT wkt = new("LINESTRING (30 10, 10 30, 40 40)"); ;
+         WKT wkt = new("LINESTRING (30 10, 10 30, 40 40)");
          string geoJson = await ConvertToGeoJsonFromWKT(wkt);
 
          Assert.IsNotNull(geoJson, "Response is empty.");
@@ -87,9 +86,9 @@ namespace GISBlox.Services.SDK.Tests
       [TestMethod]
       public async Task ConvertLineString_WKB()
       {
-         // TODO: Replace with actual WKB for LINESTRING (3010,1030,4040)
-         byte[] wkbBytes = new byte[] { /* WKB bytes for LINESTRING (3010,1030,4040) */ };
-         WKB wkb = new(wkbBytes);
+         byte[] lineString = [1, 2, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 240, 63, 0, 0, 0, 0, 0, 0, 240, 63];
+         WKB wkb = new(lineString);
+
          string geoJson = await ConvertToGeoJsonFromWKB(wkb);
 
          Assert.IsNotNull(geoJson, "Response is empty.");
@@ -109,9 +108,9 @@ namespace GISBlox.Services.SDK.Tests
       [TestMethod]
       public async Task ConvertMultiLineString_WKB()
       {
-         // TODO: Replace with actual WKB for MULTILINESTRING ((1010,2020,1040),(4040,3030,4020,3010))
-         byte[] wkbBytes = new byte[] { /* WKB bytes for MULTILINESTRING ((1010,2020,1040),(4040,3030,4020,3010)) */ };
-         WKB wkb = new(wkbBytes);
+         byte[] multiLineString = [1, 5, 0, 0, 0, 2, 0, 0, 0, 1, 2, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 36, 64, 0, 0, 0, 0, 0, 0, 36, 64, 0, 0, 0, 0, 0, 0, 52, 64, 0, 0, 0, 0, 0, 0, 52, 64, 0, 0, 0, 0, 0, 0, 36, 64, 0, 0, 0, 0, 0, 0, 68, 64, 1, 2, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 68, 64, 0, 0, 0, 0, 0, 0, 68, 64, 0, 0, 0, 0, 0, 0, 62, 64, 0, 0, 0, 0, 0, 0, 62, 64, 0, 0, 0, 0, 0, 0, 68, 64, 0, 0, 0, 0, 0, 0, 52, 64, 0, 0, 0, 0, 0, 0, 62, 64, 0, 0, 0, 0, 0, 0, 36, 64];
+         WKB wkb = new(multiLineString);
+
          string geoJson = await ConvertToGeoJsonFromWKB(wkb);
 
          Assert.IsNotNull(geoJson, "Response is empty.");
@@ -131,9 +130,9 @@ namespace GISBlox.Services.SDK.Tests
       [TestMethod]
       public async Task ConvertPolygon_WKB()
       {
-         // TODO: Replace with actual WKB for POLYGON ((3010,4040,2040,1020,3010))
-         byte[] wkbBytes = new byte[] { /* WKB bytes for POLYGON ((3010,4040,2040,1020,3010)) */ };
-         WKB wkb = new(wkbBytes);
+         byte[] polygon = [1, 3, 0, 0, 0, 1, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 62, 64, 0, 0, 0, 0, 0, 0, 36, 64, 0, 0, 0, 0, 0, 0, 68, 64, 0, 0, 0, 0, 0, 0, 68, 64, 0, 0, 0, 0, 0, 0, 52, 64, 0, 0, 0, 0, 0, 0, 68, 64, 0, 0, 0, 0, 0, 0, 36, 64, 0, 0, 0, 0, 0, 0, 52, 64, 0, 0, 0, 0, 0, 0, 62, 64, 0, 0, 0, 0, 0, 0, 36, 64];
+         WKB wkb = new(polygon);
+
          string geoJson = await ConvertToGeoJsonFromWKB(wkb);
 
          Assert.IsNotNull(geoJson, "Response is empty.");
@@ -148,19 +147,7 @@ namespace GISBlox.Services.SDK.Tests
 
          Assert.IsNotNull(geoJson, "Response is empty.");
          Assert.IsTrue(await IsValidGeoJson(geoJson, "POLYGON"), "Invalid GeoJSON.");
-      }
-
-      [TestMethod]
-      public async Task ConvertPolygonWithInnerRing_WKB()
-      {
-         // TODO: Replace with actual WKB for POLYGON ((3510,4545,1540,1020,3510),(2030,3535,3020,2030))
-         byte[] wkbBytes = new byte[] { /* WKB bytes for POLYGON ((3510,4545,1540,1020,3510),(2030,3535,3020,2030)) */ };
-         WKB wkb = new(wkbBytes);
-         string geoJson = await ConvertToGeoJsonFromWKB(wkb);
-
-         Assert.IsNotNull(geoJson, "Response is empty.");
-         Assert.IsTrue(await IsValidGeoJson(geoJson, "POLYGON"), "Invalid GeoJSON.");
-      }
+      }      
 
       [TestMethod]
       public async Task ConvertMultiPolygon()
@@ -175,9 +162,14 @@ namespace GISBlox.Services.SDK.Tests
       [TestMethod]
       public async Task ConvertMultiPolygon_WKB()
       {
-         // TODO: Replace with actual WKB for MULTIPOLYGON (((3020,4540,1040,3020)),((155,4010,1020,510,155)))
-         byte[] wkbBytes = new byte[] { /* WKB bytes for MULTIPOLYGON (((3020,4540,1040,3020)),((155,4010,1020,510,155))) */ };
-         WKB wkb = new(wkbBytes);
+         byte[] multiPolygon = [1, 6, 0, 0, 0, 2, 0, 0, 0, 1, 3, 0, 0, 0, 1, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 62, 64, 0, 0, 0, 0, 0, 0, 52, 64, 0, 0, 0, 0, 0, 128, 70, 64, 0, 0, 0, 0, 0, 0, 68, 64, 0, 0, 0, 0, 0, 0, 36, 64, 0, 0, 0, 0, 0, 0, 68, 64, 0, 0, 0, 0, 0, 0, 62, 64, 0, 0, 0, 0, 0, 0, 52, 64, 1, 3, 0, 0, 0, 1, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 46, 64, 0, 0, 0, 0, 0, 0, 20, 64, 0, 0, 0, 0, 0, 0, 68, 64, 0, 0, 0, 0, 0, 0, 36, 64, 0, 0, 0, 0, 0, 0, 36, 64, 0, 0, 0, 0, 0, 0, 52, 64, 0, 0, 0, 0, 0, 0, 20, 64, 0, 0, 0, 0, 0, 0, 36, 64, 0, 0, 0, 0, 0, 0, 46, 64, 0, 0, 0, 0, 0, 0, 20, 64];         
+         Dictionary<string, object> props = new()
+         {
+            { "id", 1 },
+            { "name", "MultiPolygon" }
+         };
+
+         WKB wkb = new(multiPolygon, [props]);
          string geoJson = await ConvertToGeoJsonFromWKB(wkb);
 
          Assert.IsNotNull(geoJson, "Response is empty.");
@@ -370,18 +362,9 @@ namespace GISBlox.Services.SDK.Tests
       /// <returns>A GeoJson string with the converted WKB geometry.</returns>
       private async Task<string> ConvertToGeoJsonFromWKB(WKB wkb, bool asFeatureCollection = false)
       {
-         // the byte array in wkb.Geometry should be sent over the line as base64 encoded string
-         string base64Geometry = Convert.ToBase64String(wkb.Geometry);
-         // we need to create a new WKT object with the base64 encoded geometry as string ???
-
-         WKT encodedWKB = new WKT
-         {
-            Geometry = base64Geometry,
-            Properties = wkb.Properties
-         };
-         return await ConvertToGeoJsonFromWKT(encodedWKB, asFeatureCollection);
+         return await _client.Conversion.ToGeoJson(wkb, asFeatureCollection);
       }
-
+   
       /// <summary>
       /// Performs a basic GeoJson validity test. It checks whether: 
       /// - The geometry type matches the expected type

--- a/GISBlox.Services.SDK/GISBlox.Services.SDK.Tests/ConversionTests.cs
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK.Tests/ConversionTests.cs
@@ -4,7 +4,11 @@ namespace GISBlox.Services.SDK.Tests
    public class ConversionTests
    {
       GISBloxClient _client;
-      const string BASE_URL = "https://services-private.gisblox.com";      
+      const string BASE_URL = "https://services-private.gisblox.com";
+
+      private const string WKB_POINT_30_10 = "AQEAAAAAAAAAAAA+QAAAAAAAACRA";
+      private static readonly byte[] WKB_POINT_30_10_BYTES = [ 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 62, 64, 0, 0, 0, 0, 0, 0, 36, 64 ];
+      private static readonly byte[] WKB_POINT_30_10_5_BYTES = [1, 233, 3, 0, 0, 0, 0, 0, 0, 0, 0, 62, 64, 0, 0, 0, 0, 0, 0, 36, 64, 0, 0, 0, 0, 0, 0, 20, 64];
 
       #region Initialization and cleanup
 
@@ -13,7 +17,7 @@ namespace GISBlox.Services.SDK.Tests
       {
          // Get the service key from the test.runsettings file
          string serviceKey = Environment.GetEnvironmentVariable("ServiceKey");
-         
+
          // Create the service client object
          _client = GISBloxClient.CreateClient(BASE_URL, serviceKey);
       }
@@ -30,20 +34,18 @@ namespace GISBlox.Services.SDK.Tests
 
       [TestMethod]
       public async Task ConvertPoint()
-      {         
+      {
          WKT wkt = new("POINT (30 10 5)");
-         string geoJson = await ConvertToGeoJsonFromWKT(wkt);         
-         
+         string geoJson = await ConvertToGeoJsonFromWKT(wkt);
+
          Assert.IsNotNull(geoJson, "Response is empty.");
          Assert.IsTrue(await IsValidGeoJson(geoJson, "POINT"), "Invalid GeoJSON.");
       }
 
       [TestMethod]
       public async Task ConvertPoint_WKB()
-      {
-         // TODO: Replace with actual WKB for POINT (30105)
-         byte[] wkbBytes = new byte[] { /* WKB bytes for POINT (30105) */ };
-         WKB wkb = new(wkbBytes);
+      { 
+         WKB wkb = new(WKB_POINT_30_10_BYTES);
          string geoJson = await ConvertToGeoJsonFromWKB(wkb);
 
          Assert.IsNotNull(geoJson, "Response is empty.");
@@ -189,7 +191,7 @@ namespace GISBlox.Services.SDK.Tests
          string geoJson = await ConvertToGeoJsonFromWKT(wkt);
 
          Assert.IsNotNull(geoJson, "Response is empty.");
-         Assert.IsTrue(await IsValidGeoJson(geoJson, "MULTIPOLYGON"), "Invalid GeoJSON.");         
+         Assert.IsTrue(await IsValidGeoJson(geoJson, "MULTIPOLYGON"), "Invalid GeoJSON.");
       }
 
       #endregion
@@ -201,11 +203,11 @@ namespace GISBlox.Services.SDK.Tests
       {
          string geoJson = "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[30,10]},\"properties\":{}}";
          var wktList = await _client.Conversion.ToWkt(geoJson, CancellationToken.None);
-         
+
          Assert.IsNotNull(wktList, "Returned WKT list is null.");
          Assert.IsGreaterThan(0, wktList.Count, "Returned WKT list is empty.");
          Assert.IsFalse(string.IsNullOrWhiteSpace(wktList[0].Geometry), "WKT geometry is empty.");
-         
+
          Assert.AreEqual("POINT(30 10)", wktList[0].Geometry);
       }
 
@@ -235,10 +237,34 @@ namespace GISBlox.Services.SDK.Tests
          string geoJson = "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[30,10]},\"properties\":{}}";
          using var stream = new System.IO.MemoryStream(System.Text.Encoding.UTF8.GetBytes(geoJson));
          var wktList = await _client.Conversion.ToWkt(stream, "test.json", CancellationToken.None);
-         
+
          Assert.IsNotNull(wktList, "Returned WKT list is null.");
          Assert.IsGreaterThan(0, wktList.Count, "Returned WKT list is empty.");
-         Assert.IsFalse(string.IsNullOrWhiteSpace(wktList[0].Geometry), "WKT geometry is empty.");
+
+         var wkt = wktList.FirstOrDefault();
+         Assert.IsFalse(string.IsNullOrWhiteSpace(wkt.Geometry), "WKT geometry is empty.");
+
+         Assert.AreEqual("POINT(30 10)", wkt.Geometry);
+      }
+
+      [TestMethod]
+      public async Task ToWktWithProperties_FromStream()
+      {
+         string geoJson = "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[30,10,5]},\"properties\":{\"zValue\":23,\"name\":\"Single Point\"}}";
+         using var stream = new System.IO.MemoryStream(System.Text.Encoding.UTF8.GetBytes(geoJson));
+         var wktList = await _client.Conversion.ToWkt(stream, "test.json", CancellationToken.None);
+
+         Assert.IsNotNull(wktList, "Returned WKT list is null.");
+         Assert.IsGreaterThan(0, wktList.Count, "Returned WKT list is empty.");
+
+         var wkt = wktList.FirstOrDefault();
+         Assert.IsFalse(string.IsNullOrWhiteSpace(wkt.Geometry), "WKT geometry is empty.");
+         Assert.AreEqual("POINT Z (30 10 5)", wkt.Geometry);
+
+         Assert.IsNotNull(wkt.Properties, "WKT properties are null.");
+         Assert.IsGreaterThan(0, wkt.Properties.Count, "WKT properties are empty.");
+         Assert.AreEqual(23L, wkt.Properties[0]["zValue"]);
+         Assert.AreEqual("Single Point", wkt.Properties[0]["name"]);
       }
 
       #endregion
@@ -250,11 +276,35 @@ namespace GISBlox.Services.SDK.Tests
       {
          string geoJson = "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[30,10]},\"properties\":{}}";
          var wkbList = await _client.Conversion.ToWkb(geoJson, CancellationToken.None);
-         
+
          Assert.IsNotNull(wkbList, "Returned WKB list is null.");
          Assert.IsGreaterThan(0, wkbList.Count, "Returned WKB list is empty.");
-         Assert.IsNotNull(wkbList[0].Geometry, "WKB geometry is null.");
-         Assert.IsGreaterThan(0, wkbList[0].Geometry.Length, "WKB geometry is empty.");
+
+         var wkb = wkbList.FirstOrDefault();
+         Assert.IsNotNull(wkb.Geometry, "WKB geometry is null.");
+         Assert.IsGreaterThan(0, wkb.Geometry.Length, "WKB geometry is empty.");
+
+         CollectionAssert.AreEqual(WKB_POINT_30_10_BYTES, wkb.Geometry, "WKB geometry does not match expected value.");
+      }
+
+      [TestMethod]
+      public async Task ToWkbWithProperties_FromString()
+      {
+         string geoJson = "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[30,10,5]},\"properties\":{\"zValue\":23,\"name\":\"Single Point\"}}";
+         var wkbList = await _client.Conversion.ToWkb(geoJson, CancellationToken.None);
+
+         Assert.IsNotNull(wkbList, "Returned WKB list is null.");
+         Assert.IsGreaterThan(0, wkbList.Count, "Returned WKB list is empty.");
+         
+         var wkb = wkbList.FirstOrDefault();
+         Assert.IsNotNull(wkb.Geometry, "WKB geometry is null.");
+         Assert.IsGreaterThan(0, wkb.Geometry.Length, "WKB geometry is empty.");
+         CollectionAssert.AreEqual(WKB_POINT_30_10_5_BYTES, wkb.Geometry, "WKB geometry does not match expected value.");
+
+         Assert.IsNotNull(wkb.Properties, "WKB properties are null.");
+         Assert.IsGreaterThan(0, wkb.Properties.Count, "WKB properties are empty.");
+         Assert.AreEqual(23L, wkb.Properties[0]["zValue"]);
+         Assert.AreEqual("Single Point", wkb.Properties[0]["name"]);
       }
 
       [TestMethod]
@@ -263,11 +313,38 @@ namespace GISBlox.Services.SDK.Tests
          string geoJson = "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[30,10]},\"properties\":{}}";
          using var stream = new System.IO.MemoryStream(System.Text.Encoding.UTF8.GetBytes(geoJson));
          var wkbList = await _client.Conversion.ToWkb(stream, "test.json", CancellationToken.None);
-         
+
          Assert.IsNotNull(wkbList, "Returned WKB list is null.");
          Assert.IsGreaterThan(0, wkbList.Count, "Returned WKB list is empty.");
-         Assert.IsNotNull(wkbList[0].Geometry, "WKB geometry is null.");
-         Assert.IsGreaterThan(0, wkbList[0].Geometry.Length, "WKB geometry is empty.");
+
+         var wkb = wkbList.FirstOrDefault();
+         Assert.IsNotNull(wkb.Geometry, "WKB geometry is null.");
+         Assert.IsGreaterThan(0, wkb.Geometry.Length, "WKB geometry is empty.");
+
+         CollectionAssert.AreEqual(WKB_POINT_30_10_BYTES, wkb.Geometry, "WKB geometry does not match expected value.");
+      }
+
+      [TestMethod]
+      public async Task ToWkbWithProperties_FromStream()
+      {
+         string geoJson = "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[30,10,5]},\"properties\":{\"zValue\":23,\"name\":\"Single Point\"}}";
+         using var stream = new System.IO.MemoryStream(System.Text.Encoding.UTF8.GetBytes(geoJson));
+         var wkbList = await _client.Conversion.ToWkb(stream, "test.json", CancellationToken.None);
+
+         Assert.IsNotNull(wkbList, "Returned WKB list is null.");
+         Assert.IsGreaterThan(0, wkbList.Count, "Returned WKB list is empty.");
+
+         var wkb = wkbList.FirstOrDefault();
+         Assert.IsNotNull(wkb.Geometry, "WKB geometry is null.");
+         Assert.IsGreaterThan(0, wkb.Geometry.Length, "WKB geometry is empty.");
+
+         CollectionAssert.AreEqual(WKB_POINT_30_10_5_BYTES, wkb.Geometry, "WKB geometry does not match expected value.");
+
+         Assert.IsNotNull(wkb.Properties, "WKB properties are null.");
+         Assert.IsGreaterThan(0, wkb.Properties.Count, "WKB properties are empty.");
+
+         Assert.AreEqual(23L, wkb.Properties[0]["zValue"]);
+         Assert.AreEqual("Single Point", wkb.Properties[0]["name"]);
       }
 
       #endregion
@@ -282,7 +359,7 @@ namespace GISBlox.Services.SDK.Tests
       /// <returns>A GeoJson string with the converted WKT geometry.</returns>
       private async Task<string> ConvertToGeoJsonFromWKT(WKT wkt, bool asFeatureCollection = false)
       {
-         return await _client.Conversion.ToGeoJson(wkt, asFeatureCollection);         
+         return await _client.Conversion.ToGeoJson(wkt, asFeatureCollection);
       }
 
       /// <summary>
@@ -293,7 +370,16 @@ namespace GISBlox.Services.SDK.Tests
       /// <returns>A GeoJson string with the converted WKB geometry.</returns>
       private async Task<string> ConvertToGeoJsonFromWKB(WKB wkb, bool asFeatureCollection = false)
       {
-         return await _client.Conversion.ToGeoJson(wkb, asFeatureCollection);
+         // the byte array in wkb.Geometry should be sent over the line as base64 encoded string
+         string base64Geometry = Convert.ToBase64String(wkb.Geometry);
+         // we need to create a new WKT object with the base64 encoded geometry as string ???
+
+         WKT encodedWKB = new WKT
+         {
+            Geometry = base64Geometry,
+            Properties = wkb.Properties
+         };
+         return await ConvertToGeoJsonFromWKT(encodedWKB, asFeatureCollection);
       }
 
       /// <summary>
@@ -313,7 +399,7 @@ namespace GISBlox.Services.SDK.Tests
             JsonElement jsonObject = doc.RootElement;
             if (jsonObject.TryGetProperty("geometry", out var typeProperty) && typeProperty.ValueKind == JsonValueKind.Object)
             {
-               if (typeProperty.TryGetProperty("type", out var geomType) && geomType.ValueKind == JsonValueKind.String)               
+               if (typeProperty.TryGetProperty("type", out var geomType) && geomType.ValueKind == JsonValueKind.String)
                {
                   // Type check
                   string typeName = geomType.GetString();
@@ -325,7 +411,7 @@ namespace GISBlox.Services.SDK.Tests
                         isValid = true;
                      }
                   }
-               }               
+               }
             }
          }
          catch (Exception)

--- a/GISBlox.Services.SDK/GISBlox.Services.SDK.Tests/ConversionTests.cs
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK.Tests/ConversionTests.cs
@@ -4,7 +4,7 @@ namespace GISBlox.Services.SDK.Tests
    public class ConversionTests
    {
       GISBloxClient _client;
-      const string BASE_URL = "https://services-private.gisblox.com";
+      const string BASE_URL = "https://services.gisblox.com";
             
       private static readonly byte[] WKB_POINT_30_10_BYTES = [ 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 62, 64, 0, 0, 0, 0, 0, 0, 36, 64 ];
       private static readonly byte[] WKB_POINT_30_10_5_BYTES = [1, 233, 3, 0, 0, 0, 0, 0, 0, 0, 0, 62, 64, 0, 0, 0, 0, 0, 0, 36, 64, 0, 0, 0, 0, 0, 0, 20, 64];

--- a/GISBlox.Services.SDK/GISBlox.Services.SDK.Tests/ConversionTests.cs
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK.Tests/ConversionTests.cs
@@ -4,8 +4,7 @@ namespace GISBlox.Services.SDK.Tests
    public class ConversionTests
    {
       GISBloxClient _client;
-      const string BASE_URL = "https://services.gisblox.com";
-      const int API_QUOTA_DELAY = 1000;  // Allows to run all tests together without exceeding API call quota
+      const string BASE_URL = "https://services-private.gisblox.com";      
 
       #region Initialization and cleanup
 
@@ -27,113 +26,274 @@ namespace GISBlox.Services.SDK.Tests
 
       #endregion
 
+      #region WKT/WKB -> GeoJson
+
       [TestMethod]
       public async Task ConvertPoint()
       {         
          WKT wkt = new("POINT (30 10 5)");
-         string geoJson = await ConvertToGeoJson(wkt);         
+         string geoJson = await ConvertToGeoJsonFromWKT(wkt);         
          
          Assert.IsNotNull(geoJson, "Response is empty.");
          Assert.IsTrue(await IsValidGeoJson(geoJson, "POINT"), "Invalid GeoJSON.");
+      }
 
-         await Task.Delay(API_QUOTA_DELAY);
+      [TestMethod]
+      public async Task ConvertPoint_WKB()
+      {
+         // TODO: Replace with actual WKB for POINT (30105)
+         byte[] wkbBytes = new byte[] { /* WKB bytes for POINT (30105) */ };
+         WKB wkb = new(wkbBytes);
+         string geoJson = await ConvertToGeoJsonFromWKB(wkb);
+
+         Assert.IsNotNull(geoJson, "Response is empty.");
+         Assert.IsTrue(await IsValidGeoJson(geoJson, "POINT"), "Invalid GeoJSON.");
       }
 
       [TestMethod]
       public async Task ConvertMultiPoint()
       {
          WKT wkt = new("MULTIPOINT ((10 40), (40 30 2), (20 20), (30 10))");
-         string geoJson = await ConvertToGeoJson(wkt);
+         string geoJson = await ConvertToGeoJsonFromWKT(wkt);
 
          Assert.IsNotNull(geoJson, "Response is empty.");
          Assert.IsTrue(await IsValidGeoJson(geoJson, "MULTIPOINT"), "Invalid GeoJSON.");
+      }
 
-         await Task.Delay(API_QUOTA_DELAY);
+      [TestMethod]
+      public async Task ConvertMultiPoint_WKB()
+      {
+         // TODO: Replace with actual WKB for MULTIPOINT ((1040), (40302), (2020), (3010))
+         byte[] wkbBytes = new byte[] { /* WKB bytes for MULTIPOINT ((1040), (40302), (2020), (3010)) */ };
+         WKB wkb = new(wkbBytes);
+         string geoJson = await ConvertToGeoJsonFromWKB(wkb);
+
+         Assert.IsNotNull(geoJson, "Response is empty.");
+         Assert.IsTrue(await IsValidGeoJson(geoJson, "MULTIPOINT"), "Invalid GeoJSON.");
       }
 
       [TestMethod]
       public async Task ConvertLineString()
       {
          WKT wkt = new("LINESTRING (30 10, 10 30, 40 40)"); ;
-         string geoJson = await ConvertToGeoJson(wkt);
+         string geoJson = await ConvertToGeoJsonFromWKT(wkt);
 
          Assert.IsNotNull(geoJson, "Response is empty.");
          Assert.IsTrue(await IsValidGeoJson(geoJson, "LINESTRING"), "Invalid GeoJSON.");
+      }
 
-         await Task.Delay(API_QUOTA_DELAY);
+      [TestMethod]
+      public async Task ConvertLineString_WKB()
+      {
+         // TODO: Replace with actual WKB for LINESTRING (3010,1030,4040)
+         byte[] wkbBytes = new byte[] { /* WKB bytes for LINESTRING (3010,1030,4040) */ };
+         WKB wkb = new(wkbBytes);
+         string geoJson = await ConvertToGeoJsonFromWKB(wkb);
+
+         Assert.IsNotNull(geoJson, "Response is empty.");
+         Assert.IsTrue(await IsValidGeoJson(geoJson, "LINESTRING"), "Invalid GeoJSON.");
       }
 
       [TestMethod]
       public async Task ConvertMultiLineString()
       {
          WKT wkt = new("MULTILINESTRING ((10 10, 20 20, 10 40),(40 40, 30 30, 40 20, 30 10))");
-         string geoJson = await ConvertToGeoJson(wkt);
+         string geoJson = await ConvertToGeoJsonFromWKT(wkt);
 
          Assert.IsNotNull(geoJson, "Response is empty.");
          Assert.IsTrue(await IsValidGeoJson(geoJson, "MULTILINESTRING"), "Invalid GeoJSON.");
+      }
 
-         await Task.Delay(API_QUOTA_DELAY);
+      [TestMethod]
+      public async Task ConvertMultiLineString_WKB()
+      {
+         // TODO: Replace with actual WKB for MULTILINESTRING ((1010,2020,1040),(4040,3030,4020,3010))
+         byte[] wkbBytes = new byte[] { /* WKB bytes for MULTILINESTRING ((1010,2020,1040),(4040,3030,4020,3010)) */ };
+         WKB wkb = new(wkbBytes);
+         string geoJson = await ConvertToGeoJsonFromWKB(wkb);
+
+         Assert.IsNotNull(geoJson, "Response is empty.");
+         Assert.IsTrue(await IsValidGeoJson(geoJson, "MULTILINESTRING"), "Invalid GeoJSON.");
       }
 
       [TestMethod]
       public async Task ConvertPolygon()
       {
          WKT wkt = new("POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))");
-         string geoJson = await ConvertToGeoJson(wkt);
+         string geoJson = await ConvertToGeoJsonFromWKT(wkt);
 
          Assert.IsNotNull(geoJson, "Response is empty.");
          Assert.IsTrue(await IsValidGeoJson(geoJson, "POLYGON"), "Invalid GeoJSON.");
+      }
 
-         await Task.Delay(API_QUOTA_DELAY);
+      [TestMethod]
+      public async Task ConvertPolygon_WKB()
+      {
+         // TODO: Replace with actual WKB for POLYGON ((3010,4040,2040,1020,3010))
+         byte[] wkbBytes = new byte[] { /* WKB bytes for POLYGON ((3010,4040,2040,1020,3010)) */ };
+         WKB wkb = new(wkbBytes);
+         string geoJson = await ConvertToGeoJsonFromWKB(wkb);
+
+         Assert.IsNotNull(geoJson, "Response is empty.");
+         Assert.IsTrue(await IsValidGeoJson(geoJson, "POLYGON"), "Invalid GeoJSON.");
       }
 
       [TestMethod]
       public async Task ConvertPolygonWithInnerRing()
       {
          WKT wkt = new("POLYGON ((35 10, 45 45, 15 40, 10 20, 35 10),(20 30, 35 35, 30 20, 20 30))");
-         string geoJson = await ConvertToGeoJson(wkt);
+         string geoJson = await ConvertToGeoJsonFromWKT(wkt);
 
          Assert.IsNotNull(geoJson, "Response is empty.");
          Assert.IsTrue(await IsValidGeoJson(geoJson, "POLYGON"), "Invalid GeoJSON.");
+      }
 
-         await Task.Delay(API_QUOTA_DELAY);
+      [TestMethod]
+      public async Task ConvertPolygonWithInnerRing_WKB()
+      {
+         // TODO: Replace with actual WKB for POLYGON ((3510,4545,1540,1020,3510),(2030,3535,3020,2030))
+         byte[] wkbBytes = new byte[] { /* WKB bytes for POLYGON ((3510,4545,1540,1020,3510),(2030,3535,3020,2030)) */ };
+         WKB wkb = new(wkbBytes);
+         string geoJson = await ConvertToGeoJsonFromWKB(wkb);
+
+         Assert.IsNotNull(geoJson, "Response is empty.");
+         Assert.IsTrue(await IsValidGeoJson(geoJson, "POLYGON"), "Invalid GeoJSON.");
       }
 
       [TestMethod]
       public async Task ConvertMultiPolygon()
       {
          WKT wkt = new("MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)),((15 5, 40 10, 10 20, 5 10, 15 5)))");
-         string geoJson = await ConvertToGeoJson(wkt);
+         string geoJson = await ConvertToGeoJsonFromWKT(wkt);
 
          Assert.IsNotNull(geoJson, "Response is empty.");
          Assert.IsTrue(await IsValidGeoJson(geoJson, "MULTIPOLYGON"), "Invalid GeoJSON.");
-         
-         await Task.Delay(API_QUOTA_DELAY);
+      }
+
+      [TestMethod]
+      public async Task ConvertMultiPolygon_WKB()
+      {
+         // TODO: Replace with actual WKB for MULTIPOLYGON (((3020,4540,1040,3020)),((155,4010,1020,510,155)))
+         byte[] wkbBytes = new byte[] { /* WKB bytes for MULTIPOLYGON (((3020,4540,1040,3020)),((155,4010,1020,510,155))) */ };
+         WKB wkb = new(wkbBytes);
+         string geoJson = await ConvertToGeoJsonFromWKB(wkb);
+
+         Assert.IsNotNull(geoJson, "Response is empty.");
+         Assert.IsTrue(await IsValidGeoJson(geoJson, "MULTIPOLYGON"), "Invalid GeoJSON.");
       }
 
       [TestMethod]
       public async Task ConvertMultiPolygonWithInnerRing()
       {
          WKT wkt = new("MULTIPOLYGON (((40 40, 20 45, 45 30, 40 40)),((20 35, 10 30, 10 10, 30 5, 45 20, 20 35),(30 20, 20 15, 20 25, 30 20)))");
-         string geoJson = await ConvertToGeoJson(wkt);
+         string geoJson = await ConvertToGeoJsonFromWKT(wkt);
 
          Assert.IsNotNull(geoJson, "Response is empty.");
-         Assert.IsTrue(await IsValidGeoJson(geoJson, "MULTIPOLYGON"), "Invalid GeoJSON.");
-
-         await Task.Delay(API_QUOTA_DELAY);
+         Assert.IsTrue(await IsValidGeoJson(geoJson, "MULTIPOLYGON"), "Invalid GeoJSON.");         
       }
+
+      #endregion
+
+      #region GeoJson -> WKT 
+
+      [TestMethod]
+      public async Task ToWkt_FromString()
+      {
+         string geoJson = "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[30,10]},\"properties\":{}}";
+         var wktList = await _client.Conversion.ToWkt(geoJson, CancellationToken.None);
+         
+         Assert.IsNotNull(wktList, "Returned WKT list is null.");
+         Assert.IsGreaterThan(0, wktList.Count, "Returned WKT list is empty.");
+         Assert.IsFalse(string.IsNullOrWhiteSpace(wktList[0].Geometry), "WKT geometry is empty.");
+         
+         Assert.AreEqual("POINT(30 10)", wktList[0].Geometry);
+      }
+
+      [TestMethod]
+      public async Task ToWktWithProperties_FromString()
+      {
+         string geoJson = "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[30,10,5]},\"properties\":{\"zValue\":23,\"name\":\"Single Point\"}}";
+         var wktList = await _client.Conversion.ToWkt(geoJson, CancellationToken.None);
+
+         Assert.IsNotNull(wktList, "Returned WKT list is null.");
+         Assert.IsGreaterThan(0, wktList.Count, "Returned WKT list is empty.");
+         Assert.IsFalse(string.IsNullOrWhiteSpace(wktList[0].Geometry), "WKT geometry is empty.");
+
+         var wkt = wktList.FirstOrDefault();
+         Assert.AreEqual("POINT Z (30 10 5)", wkt.Geometry);
+
+         Assert.IsNotNull(wkt.Properties, "WKT properties are null.");
+         Assert.IsGreaterThan(0, wkt.Properties.Count, "WKT properties are empty.");
+
+         Assert.AreEqual(23L, wkt.Properties[0]["zValue"]);
+         Assert.AreEqual("Single Point", wkt.Properties[0]["name"]);
+      }
+
+      [TestMethod]
+      public async Task ToWkt_FromStream()
+      {
+         string geoJson = "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[30,10]},\"properties\":{}}";
+         using var stream = new System.IO.MemoryStream(System.Text.Encoding.UTF8.GetBytes(geoJson));
+         var wktList = await _client.Conversion.ToWkt(stream, "test.json", CancellationToken.None);
+         
+         Assert.IsNotNull(wktList, "Returned WKT list is null.");
+         Assert.IsGreaterThan(0, wktList.Count, "Returned WKT list is empty.");
+         Assert.IsFalse(string.IsNullOrWhiteSpace(wktList[0].Geometry), "WKT geometry is empty.");
+      }
+
+      #endregion
+
+      #region GeoJson -> WKB
+
+      [TestMethod]
+      public async Task ToWkb_FromString()
+      {
+         string geoJson = "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[30,10]},\"properties\":{}}";
+         var wkbList = await _client.Conversion.ToWkb(geoJson, CancellationToken.None);
+         
+         Assert.IsNotNull(wkbList, "Returned WKB list is null.");
+         Assert.IsGreaterThan(0, wkbList.Count, "Returned WKB list is empty.");
+         Assert.IsNotNull(wkbList[0].Geometry, "WKB geometry is null.");
+         Assert.IsGreaterThan(0, wkbList[0].Geometry.Length, "WKB geometry is empty.");
+      }
+
+      [TestMethod]
+      public async Task ToWkb_FromStream()
+      {
+         string geoJson = "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[30,10]},\"properties\":{}}";
+         using var stream = new System.IO.MemoryStream(System.Text.Encoding.UTF8.GetBytes(geoJson));
+         var wkbList = await _client.Conversion.ToWkb(stream, "test.json", CancellationToken.None);
+         
+         Assert.IsNotNull(wkbList, "Returned WKB list is null.");
+         Assert.IsGreaterThan(0, wkbList.Count, "Returned WKB list is empty.");
+         Assert.IsNotNull(wkbList[0].Geometry, "WKB geometry is null.");
+         Assert.IsGreaterThan(0, wkbList[0].Geometry.Length, "WKB geometry is empty.");
+      }
+
+      #endregion
 
       #region Private methods
 
       /// <summary>
-      /// Calls the API and returns the results.
+      /// Converts a WKT geometry into a GeoJson Feature(Collection) string.
       /// </summary>
-      /// <param name="wkt">A WKT geometry string.</param>
+      /// <param name="wkt">A WKT type.</param>
       /// <param name="asFeatureCollection">Indicates whether to include the GeoJson feature in a feature collection.</param>
       /// <returns>A GeoJson string with the converted WKT geometry.</returns>
-      private async Task<string> ConvertToGeoJson(WKT wkt, bool asFeatureCollection = false)
+      private async Task<string> ConvertToGeoJsonFromWKT(WKT wkt, bool asFeatureCollection = false)
       {
          return await _client.Conversion.ToGeoJson(wkt, asFeatureCollection);         
+      }
+
+      /// <summary>
+      /// Converts a WKB geometry into a GeoJson Feature(Collection) string.
+      /// </summary>
+      /// <param name="wkb">A WKB type.</param>
+      /// <param name="asFeatureCollection">Indicates whether to include the GeoJson feature in a feature collection.</param>
+      /// <returns>A GeoJson string with the converted WKB geometry.</returns>
+      private async Task<string> ConvertToGeoJsonFromWKB(WKB wkb, bool asFeatureCollection = false)
+      {
+         return await _client.Conversion.ToGeoJson(wkb, asFeatureCollection);
       }
 
       /// <summary>

--- a/GISBlox.Services.SDK/GISBlox.Services.SDK/Common/PropertyValueNormalizer.cs
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK/Common/PropertyValueNormalizer.cs
@@ -1,0 +1,200 @@
+// ------------------------------------------------------------
+// Copyright (c) Bartels Online. All rights reserved.
+// ------------------------------------------------------------
+
+using GISBlox.Services.SDK.Models;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.Json;
+
+namespace GISBlox.Services.SDK.Common
+{
+   /// <summary>
+   /// Normalizes property dictionaries by converting wrapper objects that contain a Value and ValueType
+   /// into concrete CLR types. Only intended for use with Conversion API results (ToWkt/ToWkb).
+   /// </summary>
+   internal static class PropertyValueNormalizer
+   {
+      /// <summary>
+      /// Normalize properties for a list of WKT results.
+      /// </summary>
+      public static void NormalizeWktList(List<WKT> wkts)
+      {
+         if (wkts == null) return;
+         foreach (var w in wkts)
+         {
+            NormalizePropertyBags(w?.Properties);
+         }
+      }
+
+      /// <summary>
+      /// Normalize properties for a list of WKB results.
+      /// </summary>
+      public static void NormalizeWkbList(List<WKB> wkbs)
+      {
+         if (wkbs == null) return;
+         foreach (var w in wkbs)
+         {
+            NormalizePropertyBags(w?.Properties);
+         }
+      }
+
+      private static void NormalizePropertyBags(List<Dictionary<string, object>> bags)
+      {
+         if (bags == null) return;
+         foreach (var bag in bags)
+         {
+            NormalizeDictionary(bag);
+         }
+      }
+
+      private static void NormalizeDictionary(Dictionary<string, object> dict)
+      {
+         if (dict == null) return;
+         var keys = new List<string>(dict.Keys);
+         foreach (var key in keys)
+         {
+            dict[key] = NormalizeValue(dict[key]);
+         }
+      }
+
+      private static object NormalizeValue(object value)
+      {
+         // Unwrap JsonElement to CLR values if present
+         value = UnwrapJsonElement(value);
+
+         // Handle wrapper objects with Value/ValueType contract
+         if (value is Dictionary<string, object> nested)
+         {
+            // Try to find keys (case-insensitive): Value and ValueType
+            string valueKey = null;
+            string typeKey = null;
+            foreach (var k in nested.Keys)
+            {
+               if (valueKey == null && string.Equals(k, "Value", StringComparison.OrdinalIgnoreCase)) valueKey = k;
+               if (typeKey == null && string.Equals(k, "ValueType", StringComparison.OrdinalIgnoreCase)) typeKey = k;
+            }
+
+            if (valueKey != null && typeKey != null)
+            {
+               var rawType = nested[typeKey]?.ToString();
+               var rawValue = UnwrapJsonElement(nested[valueKey]);
+               return ConvertByValueType(rawValue, rawType);
+            }
+
+            // Otherwise, recursively normalize nested dictionaries
+            NormalizeDictionary(nested);
+            return nested;
+         }
+
+         // Normalize lists/arrays
+         if (value is List<object> list)
+         {
+            for (int i = 0; i < list.Count; i++)
+            {
+               list[i] = NormalizeValue(list[i]);
+            }
+            return list;
+         }
+
+         return value;
+      }
+
+      private static object UnwrapJsonElement(object value)
+      {
+         if (value is JsonElement je)
+         {
+            switch (je.ValueKind)
+            {
+               case JsonValueKind.Null:
+               case JsonValueKind.Undefined:
+                  return null;
+               case JsonValueKind.True:
+                  return true;
+               case JsonValueKind.False:
+                  return false;
+               case JsonValueKind.Number:
+                  if (je.TryGetInt64(out long l)) return l;
+                  if (je.TryGetDecimal(out decimal m)) return m;
+                  return je.GetDouble();
+               case JsonValueKind.String:
+                  if (je.TryGetDateTime(out var dt)) return dt;
+                  return je.GetString();
+               case JsonValueKind.Object:
+                  {
+                     var dict = new Dictionary<string, object>(StringComparer.Ordinal);
+                     foreach (var prop in je.EnumerateObject())
+                     {
+                        dict[prop.Name] = UnwrapJsonElement(prop.Value);
+                     }
+                     return dict;
+                  }
+               case JsonValueKind.Array:
+                  {
+                     var list = new List<object>();
+                     foreach (var item in je.EnumerateArray())
+                     {
+                        list.Add(UnwrapJsonElement(item));
+                     }
+                     return list;
+                  }
+            }
+         }
+         return value;
+      }
+
+      private static object ConvertByValueType(object value, string valueType)
+      {
+         if (string.IsNullOrWhiteSpace(valueType)) return value;
+         var t = valueType.Trim();
+
+         // Normalize type token
+         t = t.Replace("System.", string.Empty, StringComparison.OrdinalIgnoreCase);
+
+         switch (t.ToLowerInvariant())
+         {
+            case "string":
+               return value?.ToString();
+            case "int":
+            case "int32":
+               return value == null ? 0 : Convert.ToInt32(value, CultureInfo.InvariantCulture);
+            case "long":
+            case "int64":
+               return value == null ? 0L : Convert.ToInt64(value, CultureInfo.InvariantCulture);
+            case "double":
+               return value == null ? 0d : Convert.ToDouble(value, CultureInfo.InvariantCulture);
+            case "decimal":
+               return value == null ? 0m : Convert.ToDecimal(value, CultureInfo.InvariantCulture);
+            case "float":
+            case "single":
+               return value == null ? 0f : Convert.ToSingle(value, CultureInfo.InvariantCulture);
+            case "bool":
+            case "boolean":
+               return value != null && Convert.ToBoolean(value, CultureInfo.InvariantCulture);
+            case "datetime":
+            case "date":
+               if (value is DateTime dt) return dt;
+               if (value is long ticks) return new DateTime(ticks);
+               if (DateTime.TryParse(Convert.ToString(value, CultureInfo.InvariantCulture), CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed))
+                  return parsed;
+               return value;
+            case "guid":
+               if (value is Guid g) return g;
+               if (Guid.TryParse(Convert.ToString(value, CultureInfo.InvariantCulture), out var guid))
+                  return guid;
+               return value;
+            case "byte[]":
+            case "binary":
+            case "bytes":
+               if (value is byte[] b) return b;
+               var s = Convert.ToString(value, CultureInfo.InvariantCulture);
+               try { return Convert.FromBase64String(s); } catch { return value; }
+            case "null":
+               return null;
+            default:
+               return value;
+         }
+      }
+   }
+}

--- a/GISBlox.Services.SDK/GISBlox.Services.SDK/Conversion/ConversionAPIClient.cs
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK/Conversion/ConversionAPIClient.cs
@@ -2,42 +2,126 @@
 // Copyright (c) Bartels Online.  All rights reserved.
 // ------------------------------------------------------------
 
+using GISBlox.Services.SDK.Common;
 using GISBlox.Services.SDK.Models;
 using Microsoft.Extensions.Caching.Memory;
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace GISBlox.Services.SDK.Conversion
 {
-    /// <summary>
-    /// This class converts WKT geometry objects into GeoJSON. 
-    /// </summary>
-    /// <remarks>
-    /// Initializes a new instance of the GISBlox.Services.SDK.Conversion.ConversionAPIClient class.
-    /// </remarks>
-    /// <param name="httpClient">The current instance of the HTTPClient class.</param>
-    /// <param name="cache">The current instance of the MemoryCache class.</param>
-    public class ConversionAPIClient(HttpClient httpClient, IMemoryCache cache) : ApiClient(httpClient, cache), IConversionAPI
-    {
-        /// <summary>
-        /// Converts a WKT geometry string into a GeoJson Feature(Collection) string.
-        /// </summary>
-        /// <param name="wkt">A WKT type.</param>
-        /// <param name="asFeatureCollection">Indicates whether to include the GeoJson feature in a feature collection.</param>
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>A GeoJson string with the converted WKT geometry.</returns>
-        public async Task<string> ToGeoJson(WKT wkt, bool asFeatureCollection = false, CancellationToken cancellationToken = default)
-        {
-            var requestUri = "convert/toGeoJson";
+   /// <summary>
+   /// This class converts WKT geometry objects into GeoJSON. 
+   /// </summary>
+   /// <remarks>
+   /// Initializes a new instance of the GISBlox.Services.SDK.Conversion.ConversionAPIClient class.
+   /// </remarks>
+   /// <param name="httpClient">The current instance of the HTTPClient class.</param>
+   /// <param name="cache">The current instance of the MemoryCache class.</param>
+   public class ConversionAPIClient(HttpClient httpClient, IMemoryCache cache) : ApiClient(httpClient, cache), IConversionAPI
+   {
+      /// <summary>
+      /// Converts a WKT geometry string into a GeoJson Feature(Collection) string.
+      /// </summary>
+      /// <param name="wkt">A WKT type.</param>
+      /// <param name="asFeatureCollection">Indicates whether to include the GeoJson feature in a feature collection.</param>
+      /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+      /// <returns>A GeoJson string with the converted WKT geometry.</returns>
+      public async Task<string> ToGeoJson(WKT wkt, bool asFeatureCollection = false, CancellationToken cancellationToken = default)
+      {
+         var requestUri = "convert/toGeoJson?source=WKT";
 
-            Dictionary<string, string> customHeaders = new()
+         Dictionary<string, string> customHeaders = new()
             {
                 { "X-AsFeatureCollection", asFeatureCollection ? "1" : "0" }
             };
 
-            return await HttpPost<dynamic, string>(HttpClient, requestUri, wkt, null, customHeaders, cancellationToken);
-        }
-    }
+         return await HttpPost<dynamic, string>(HttpClient, requestUri, wkt, null, customHeaders, cancellationToken);
+      }
+
+      /// <summary>
+      /// Converts a WKB geometry into a GeoJson Feature(Collection) string.
+      /// </summary>
+      /// <param name="wkb">A WKB type.</param>
+      /// <param name="asFeatureCollection">Indicates whether to include the GeoJson feature in a feature collection.</param>
+      /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+      /// <returns>A GeoJson string with the converted WKB geometry.</returns>
+      public async Task<string> ToGeoJson(WKB wkb, bool asFeatureCollection = false, CancellationToken cancellationToken = default)
+      {
+         var requestUri = "convert/toGeoJson?source=WKB";
+
+         Dictionary<string, string> customHeaders = new()
+            {
+                { "X-AsFeatureCollection", asFeatureCollection ? "1" : "0" }
+            };
+
+         return await HttpPost<dynamic, string>(HttpClient, requestUri, wkb, null, customHeaders, cancellationToken);
+      }
+
+      /// <summary>
+      /// Converts a GeoJson string into a list of WKB geometries.
+      /// </summary>
+      /// <param name="geoJson">A GeoJson string.</param>
+      /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+      /// <returns>A list of WKB geometries.</returns>
+      public async Task<List<WKB>> ToWkb(string geoJson, CancellationToken cancellationToken = default)
+      {
+         var requestUri = "convert/toWkb";
+         
+         var result = await HttpPost<string, List<WKB>>(HttpClient, requestUri, geoJson, null, null, cancellationToken);
+         PropertyValueNormalizer.NormalizeWkbList(result);
+         return result;
+      }
+
+      /// <summary>
+      /// Converts a GeoJson stream into a list of WKB geometries.
+      /// </summary>
+      /// <param name="stream">A stream containing the GeoJson data.</param>
+      /// <param name="fileName">The name of the file.</param>
+      /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+      /// <returns>A list of WKB geometries.</returns>
+      public async Task<List<WKB>> ToWkb(Stream stream, string fileName, CancellationToken cancellationToken = default)
+      {
+         var requestUri = "convert/toWkb/" + fileName;
+         
+         var result = await HttpPost<Stream, List<WKB>>(HttpClient, requestUri, stream, null, null, cancellationToken);
+         PropertyValueNormalizer.NormalizeWkbList(result);
+         return result;
+      }
+
+      /// <summary>
+      /// Converts a GeoJson string into a list of WKT geometries.
+      /// </summary>
+      /// <param name="geoJson">A GeoJson string.</param>
+      /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+      /// <returns>A list of WKT geometries.</returns>
+      public async Task<List<WKT>> ToWkt(string geoJson, CancellationToken cancellationToken = default)
+      {
+         var requestUri = "convert/toWkt";
+         
+         var result = await HttpPost<string, List<WKT>>(HttpClient, requestUri, geoJson, null, null, cancellationToken);
+         PropertyValueNormalizer.NormalizeWktList(result);
+         return result;
+      }
+
+      /// <summary>
+      /// Converts a GeoJson string into a list of WKT geometries.
+      /// </summary>
+      /// <param name="stream">A stream containing the GeoJson data.</param>
+      /// <param name="fileName">The name of the file.</param>
+      /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+      /// <returns>A list of WKT geometries.</returns>
+      public async Task<List<WKT>> ToWkt(Stream stream, string fileName, CancellationToken cancellationToken = default)
+      {
+         var requestUri = "convert/toWkt/" + fileName;
+         
+         var result = await HttpPost<Stream, List<WKT>>(HttpClient, requestUri, stream, null, null, cancellationToken);
+         PropertyValueNormalizer.NormalizeWktList(result);
+         return result;
+      }     
+   }
 }

--- a/GISBlox.Services.SDK/GISBlox.Services.SDK/Conversion/ConversionAPIClient.cs
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK/Conversion/ConversionAPIClient.cs
@@ -32,7 +32,7 @@ namespace GISBlox.Services.SDK.Conversion
       /// <returns>A GeoJson string with the converted WKT geometry.</returns>
       public async Task<string> ToGeoJson(WKT wkt, bool asFeatureCollection = false, CancellationToken cancellationToken = default)
       {
-         var requestUri = "convert/toGeoJson?source=WKT";
+         var requestUri = "convert/toGeoJson?format=WKT";
 
          Dictionary<string, string> customHeaders = new()
             {
@@ -51,7 +51,7 @@ namespace GISBlox.Services.SDK.Conversion
       /// <returns>A GeoJson string with the converted WKB geometry.</returns>
       public async Task<string> ToGeoJson(WKB wkb, bool asFeatureCollection = false, CancellationToken cancellationToken = default)
       {
-         var requestUri = "convert/toGeoJson?source=WKB";
+         var requestUri = "convert/toGeoJson?format=WKB";
 
          Dictionary<string, string> customHeaders = new()
             {

--- a/GISBlox.Services.SDK/GISBlox.Services.SDK/Conversion/ConversionAPIClient.cs
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK/Conversion/ConversionAPIClient.cs
@@ -5,7 +5,6 @@
 using GISBlox.Services.SDK.Common;
 using GISBlox.Services.SDK.Models;
 using Microsoft.Extensions.Caching.Memory;
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
@@ -87,8 +86,8 @@ namespace GISBlox.Services.SDK.Conversion
       public async Task<List<WKB>> ToWkb(Stream stream, string fileName, CancellationToken cancellationToken = default)
       {
          var requestUri = "convert/toWkb/" + fileName;
-         
-         var result = await HttpPost<Stream, List<WKB>>(HttpClient, requestUri, stream, null, null, cancellationToken);
+
+         var result = await HttpPost<List<WKB>>(HttpClient, requestUri, stream, "application/json", null, cancellationToken);
          PropertyValueNormalizer.NormalizeWkbList(result);
          return result;
       }
@@ -118,8 +117,8 @@ namespace GISBlox.Services.SDK.Conversion
       public async Task<List<WKT>> ToWkt(Stream stream, string fileName, CancellationToken cancellationToken = default)
       {
          var requestUri = "convert/toWkt/" + fileName;
-         
-         var result = await HttpPost<Stream, List<WKT>>(HttpClient, requestUri, stream, null, null, cancellationToken);
+
+         var result = await HttpPost<List<WKT>>(HttpClient, requestUri, stream, "application/json", null, cancellationToken);         
          PropertyValueNormalizer.NormalizeWktList(result);
          return result;
       }     

--- a/GISBlox.Services.SDK/GISBlox.Services.SDK/Conversion/IConversionAPI.cs
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK/Conversion/IConversionAPI.cs
@@ -4,6 +4,8 @@
 
 using GISBlox.Services.SDK.Models;
 using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -12,7 +14,7 @@ namespace GISBlox.Services.SDK.Conversion
    /// <summary>
    /// Interface for ConversionAPI class.
    /// </summary>
-   public interface IConversionAPI : IDisposable 
+   public interface IConversionAPI : IDisposable
    {
       /// <summary>
       /// Converts a WKT geometry string into a GeoJson Feature(Collection) string.
@@ -21,6 +23,49 @@ namespace GISBlox.Services.SDK.Conversion
       /// <param name="asFeatureCollection">Indicates whether to include the GeoJson feature in a feature collection.</param>
       /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
       /// <returns>A GeoJson string with the converted WKT geometry.</returns>
-      Task<string> ToGeoJson(WKT wkt, bool asFeatureCollection = false, CancellationToken cancellationToken = default);   
+      Task<string> ToGeoJson(WKT wkt, bool asFeatureCollection = false, CancellationToken cancellationToken = default);
+
+      /// <summary>
+      /// Converts a WKB geometry into a GeoJson Feature(Collection) string.
+      /// </summary>
+      /// <param name="wkb">A WKB type.</param>
+      /// <param name="asFeatureCollection">Indicates whether to include the GeoJson feature in a feature collection.</param>
+      /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+      /// <returns>A GeoJson string with the converted WKB geometry.</returns>
+      Task<string> ToGeoJson(WKB wkb, bool asFeatureCollection = false, CancellationToken cancellationToken = default);
+      
+      /// <summary>
+      /// Converts a GeoJson string into a list of WKB geometries.
+      /// </summary>
+      /// <param name="geoJson">A GeoJson string.</param>
+      /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+      /// <returns>A list of WKB geometries.</returns>
+      Task<List<WKB>> ToWkb(string geoJson, CancellationToken cancellationToken = default);
+
+      /// <summary>
+      /// Converts a GeoJson stream into a list of WKB geometries.
+      /// </summary>
+      /// <param name="stream">A stream containing the GeoJson data.</param>
+      /// <param name="fileName">The name of the file.</param>
+      /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+      /// <returns>A list of WKB geometries.</returns>
+      Task<List<WKB>> ToWkb(Stream stream, string fileName, CancellationToken cancellationToken = default);
+
+      /// <summary>
+      /// Converts a GeoJson string into a list of WKT geometries.
+      /// </summary>
+      /// <param name="geoJson">A GeoJson string.</param>
+      /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+      /// <returns>A list of WKT geometries.</returns>
+      Task<List<WKT>> ToWkt(string geoJson, CancellationToken cancellationToken = default);
+
+      /// <summary>
+      /// Converts a GeoJson string into a list of WKT geometries.
+      /// </summary>
+      /// <param name="stream">A stream containing the GeoJson data.</param>
+      /// <param name="fileName">The name of the file.</param>
+      /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+      /// <returns>A list of WKT geometries.</returns>
+      Task<List<WKT>> ToWkt(Stream stream, string fileName, CancellationToken cancellationToken = default);
    }
 }

--- a/GISBlox.Services.SDK/GISBlox.Services.SDK/GISBlox.Services.SDK.xml
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK/GISBlox.Services.SDK.xml
@@ -239,6 +239,22 @@
             The HTTP status code of the error.
             </summary>
         </member>
+        <member name="T:GISBlox.Services.SDK.Common.PropertyValueNormalizer">
+            <summary>
+            Normalizes property dictionaries by converting wrapper objects that contain a Value and ValueType
+            into concrete CLR types. Only intended for use with Conversion API results (ToWkt/ToWkb).
+            </summary>
+        </member>
+        <member name="M:GISBlox.Services.SDK.Common.PropertyValueNormalizer.NormalizeWktList(System.Collections.Generic.List{GISBlox.Services.SDK.Models.WKT})">
+            <summary>
+            Normalize properties for a list of WKT results.
+            </summary>
+        </member>
+        <member name="M:GISBlox.Services.SDK.Common.PropertyValueNormalizer.NormalizeWkbList(System.Collections.Generic.List{GISBlox.Services.SDK.Models.WKB})">
+            <summary>
+            Normalize properties for a list of WKB results.
+            </summary>
+        </member>
         <member name="T:GISBlox.Services.SDK.Conversion.ConversionAPIClient">
             <summary>
             This class converts WKT geometry objects into GeoJSON. 
@@ -268,6 +284,49 @@
             <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
             <returns>A GeoJson string with the converted WKT geometry.</returns>
         </member>
+        <member name="M:GISBlox.Services.SDK.Conversion.ConversionAPIClient.ToGeoJson(GISBlox.Services.SDK.Models.WKB,System.Boolean,System.Threading.CancellationToken)">
+            <summary>
+            Converts a WKB geometry into a GeoJson Feature(Collection) string.
+            </summary>
+            <param name="wkb">A WKB type.</param>
+            <param name="asFeatureCollection">Indicates whether to include the GeoJson feature in a feature collection.</param>
+            <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+            <returns>A GeoJson string with the converted WKB geometry.</returns>
+        </member>
+        <member name="M:GISBlox.Services.SDK.Conversion.ConversionAPIClient.ToWkb(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Converts a GeoJson string into a list of WKB geometries.
+            </summary>
+            <param name="geoJson">A GeoJson string.</param>
+            <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+            <returns>A list of WKB geometries.</returns>
+        </member>
+        <member name="M:GISBlox.Services.SDK.Conversion.ConversionAPIClient.ToWkb(System.IO.Stream,System.String,System.Threading.CancellationToken)">
+            <summary>
+            Converts a GeoJson stream into a list of WKB geometries.
+            </summary>
+            <param name="stream">A stream containing the GeoJson data.</param>
+            <param name="fileName">The name of the file.</param>
+            <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+            <returns>A list of WKB geometries.</returns>
+        </member>
+        <member name="M:GISBlox.Services.SDK.Conversion.ConversionAPIClient.ToWkt(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Converts a GeoJson string into a list of WKT geometries.
+            </summary>
+            <param name="geoJson">A GeoJson string.</param>
+            <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+            <returns>A list of WKT geometries.</returns>
+        </member>
+        <member name="M:GISBlox.Services.SDK.Conversion.ConversionAPIClient.ToWkt(System.IO.Stream,System.String,System.Threading.CancellationToken)">
+            <summary>
+            Converts a GeoJson string into a list of WKT geometries.
+            </summary>
+            <param name="stream">A stream containing the GeoJson data.</param>
+            <param name="fileName">The name of the file.</param>
+            <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+            <returns>A list of WKT geometries.</returns>
+        </member>
         <member name="T:GISBlox.Services.SDK.Conversion.IConversionAPI">
             <summary>
             Interface for ConversionAPI class.
@@ -281,6 +340,49 @@
             <param name="asFeatureCollection">Indicates whether to include the GeoJson feature in a feature collection.</param>
             <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
             <returns>A GeoJson string with the converted WKT geometry.</returns>
+        </member>
+        <member name="M:GISBlox.Services.SDK.Conversion.IConversionAPI.ToGeoJson(GISBlox.Services.SDK.Models.WKB,System.Boolean,System.Threading.CancellationToken)">
+            <summary>
+            Converts a WKB geometry into a GeoJson Feature(Collection) string.
+            </summary>
+            <param name="wkb">A WKB type.</param>
+            <param name="asFeatureCollection">Indicates whether to include the GeoJson feature in a feature collection.</param>
+            <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+            <returns>A GeoJson string with the converted WKB geometry.</returns>
+        </member>
+        <member name="M:GISBlox.Services.SDK.Conversion.IConversionAPI.ToWkb(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Converts a GeoJson string into a list of WKB geometries.
+            </summary>
+            <param name="geoJson">A GeoJson string.</param>
+            <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+            <returns>A list of WKB geometries.</returns>
+        </member>
+        <member name="M:GISBlox.Services.SDK.Conversion.IConversionAPI.ToWkb(System.IO.Stream,System.String,System.Threading.CancellationToken)">
+            <summary>
+            Converts a GeoJson stream into a list of WKB geometries.
+            </summary>
+            <param name="stream">A stream containing the GeoJson data.</param>
+            <param name="fileName">The name of the file.</param>
+            <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+            <returns>A list of WKB geometries.</returns>
+        </member>
+        <member name="M:GISBlox.Services.SDK.Conversion.IConversionAPI.ToWkt(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Converts a GeoJson string into a list of WKT geometries.
+            </summary>
+            <param name="geoJson">A GeoJson string.</param>
+            <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+            <returns>A list of WKT geometries.</returns>
+        </member>
+        <member name="M:GISBlox.Services.SDK.Conversion.IConversionAPI.ToWkt(System.IO.Stream,System.String,System.Threading.CancellationToken)">
+            <summary>
+            Converts a GeoJson string into a list of WKT geometries.
+            </summary>
+            <param name="stream">A stream containing the GeoJson data.</param>
+            <param name="fileName">The name of the file.</param>
+            <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+            <returns>A list of WKT geometries.</returns>
         </member>
         <member name="T:GISBlox.Services.SDK.DataLake.DataLakeAPIClient">
             <summary>
@@ -555,9 +657,42 @@
             Specifies whether the subscription has expired.
             </summary>
         </member>
+        <member name="T:GISBlox.Services.SDK.Models.WKB">
+            <summary>
+            This class represents a WKB geometry and its properties.
+            </summary>
+        </member>
+        <member name="P:GISBlox.Services.SDK.Models.WKB.Geometry">
+            <summary>
+            Specifies the WKB geometry.
+            </summary>
+        </member>
+        <member name="P:GISBlox.Services.SDK.Models.WKB.Properties">
+            <summary>
+            Specifies the properties associated with the WKB geometry.
+            </summary>
+        </member>
+        <member name="M:GISBlox.Services.SDK.Models.WKB.#ctor">
+            <summary>
+            Initializes a new instance of GISBlox.Models.Conversion.WKB class.
+            </summary>
+        </member>
+        <member name="M:GISBlox.Services.SDK.Models.WKB.#ctor(System.Byte[])">
+            <summary>
+            Initializes a new instance of GISBlox.Models.Conversion.WKB class with the specified geometry.
+            </summary>
+            <param name="geometry">The WKB geometry.</param>
+        </member>
+        <member name="M:GISBlox.Services.SDK.Models.WKB.#ctor(System.Byte[],System.Collections.Generic.List{System.Collections.Generic.Dictionary{System.String,System.Object}})">
+            <summary>
+            Initializes a new instance of GISBlox.Models.Conversion.WKB class with the specified geometry and properties.
+            </summary>
+            <param name="geometry">The WKB geometry.</param>
+            <param name="properties">The properties associated with the WKB geometry.</param>
+        </member>
         <member name="T:GISBlox.Services.SDK.Models.WKT">
             <summary>
-            This class represents a WKT geometry string representation.
+            This class represents a WKT geometry string and its properties.
             </summary>
         </member>
         <member name="P:GISBlox.Services.SDK.Models.WKT.Geometry">
@@ -565,16 +700,28 @@
             Specifies the WKT geometry.
             </summary>
         </member>
+        <member name="P:GISBlox.Services.SDK.Models.WKT.Properties">
+            <summary>
+            Specifies the properties associated with the WKT geometry.
+            </summary>
+        </member>
         <member name="M:GISBlox.Services.SDK.Models.WKT.#ctor">
             <summary>
-            Initializes a new instance of the GISBlox.Services.SDK.Models.WKT class.
+            Initializes a new instance of GISBlox.Models.Conversion.WKT class.
             </summary>
         </member>
         <member name="M:GISBlox.Services.SDK.Models.WKT.#ctor(System.String)">
             <summary>
-            Initializes a new instance of the GISBlox.Services.SDK.Models.WKT class.
+            Initializes a new instance of GISBlox.Models.Conversion.WKT class.
             </summary>
             <param name="geometry">A WKT geometry.</param>
+        </member>
+        <member name="M:GISBlox.Services.SDK.Models.WKT.#ctor(System.String,System.Collections.Generic.List{System.Collections.Generic.Dictionary{System.String,System.Object}})">
+            <summary>
+            Initializes a new instance of GISBlox.Models.Conversion.WKT class.
+            </summary>
+            <param name="geometry">A WKT geometry.</param>
+            <param name="properties">A list of properties associated with the geometry.</param>
         </member>
         <member name="T:GISBlox.Services.SDK.Models.CustomerFiles">
             <summary>

--- a/GISBlox.Services.SDK/GISBlox.Services.SDK/Models/Conversion/WKB.cs
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK/Models/Conversion/WKB.cs
@@ -1,0 +1,50 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Bartels Online.  All rights reserved.
+// ------------------------------------------------------------
+
+using System.Collections.Generic;
+
+namespace GISBlox.Services.SDK.Models
+{
+   /// <summary>
+   /// This class represents a WKB geometry and its properties.
+   /// </summary>
+   public class WKB
+   {
+      /// <summary>
+      /// Specifies the WKB geometry.
+      /// </summary>
+      public byte[] Geometry { get; set; }
+
+      /// <summary>
+      /// Specifies the properties associated with the WKB geometry.
+      /// </summary>
+      public List<Dictionary<string, object>> Properties { get; set; }
+
+      /// <summary>
+      /// Initializes a new instance of GISBlox.Models.Conversion.WKB class.
+      /// </summary>
+      public WKB()
+      { }
+
+      /// <summary>
+      /// Initializes a new instance of GISBlox.Models.Conversion.WKB class with the specified geometry.
+      /// </summary>
+      /// <param name="geometry">The WKB geometry.</param>
+      public WKB(byte[] geometry)
+      {
+         this.Geometry = geometry;
+      }
+
+      /// <summary>
+      /// Initializes a new instance of GISBlox.Models.Conversion.WKB class with the specified geometry and properties.
+      /// </summary>
+      /// <param name="geometry">The WKB geometry.</param>
+      /// <param name="properties">The properties associated with the WKB geometry.</param>
+      public WKB(byte[] geometry, List<Dictionary<string, object>> properties)
+      {
+         this.Geometry = geometry;
+         this.Properties = properties;
+      }
+   }
+}

--- a/GISBlox.Services.SDK/GISBlox.Services.SDK/Models/Conversion/WKT.cs
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK/Models/Conversion/WKT.cs
@@ -2,10 +2,12 @@
 // Copyright (c) Bartels Online.  All rights reserved.
 // ------------------------------------------------------------
 
+using System.Collections.Generic;
+
 namespace GISBlox.Services.SDK.Models
 {
    /// <summary>
-   /// This class represents a WKT geometry string representation.
+   /// This class represents a WKT geometry string and its properties.
    /// </summary>
    public class WKT
    {
@@ -15,18 +17,34 @@ namespace GISBlox.Services.SDK.Models
       public string Geometry { get; set; }
 
       /// <summary>
-      /// Initializes a new instance of the GISBlox.Services.SDK.Models.WKT class.
+      /// Specifies the properties associated with the WKT geometry.
+      /// </summary>
+      public List<Dictionary<string, object>> Properties { get; set; }
+
+      /// <summary>
+      /// Initializes a new instance of GISBlox.Models.Conversion.WKT class.
       /// </summary>
       public WKT()
       { }
 
       /// <summary>
-      /// Initializes a new instance of the GISBlox.Services.SDK.Models.WKT class.
+      /// Initializes a new instance of GISBlox.Models.Conversion.WKT class.
       /// </summary>
       /// <param name="geometry">A WKT geometry.</param>
       public WKT(string geometry)
       {
          this.Geometry = geometry;
+      }
+
+      /// <summary>
+      /// Initializes a new instance of GISBlox.Models.Conversion.WKT class.
+      /// </summary>
+      /// <param name="geometry">A WKT geometry.</param>
+      /// <param name="properties">A list of properties associated with the geometry.</param>
+      public WKT(string geometry, List<Dictionary<string, object>> properties)
+      {
+         this.Geometry = geometry;
+         this.Properties = properties;
       }
    }
 }


### PR DESCRIPTION
#### PR Summary
This pull request introduces new functionality for handling WKB geometries, enhancing the SDK's capability to work with different geometry formats.
- `ConversionTests.cs`: Added test methods for converting WKB geometries to GeoJSON and vice versa.
- `ConversionAPIClient.cs`: Added methods for converting GeoJSON to WKB and WKT, including property normalization.
- `PropertyValueNormalizer.cs`: Introduced a static class for normalizing property dictionaries.
- `IConversionAPI.cs`: Updated interface to include new conversion methods for GeoJSON to WKB and WKT.
- `WKB.cs`: Added a new class representing WKB geometry and its properties.
