### PR TITLE
Add Map Analytics API

### DIFF
--- a/GISBlox.Services.SDK/GISBlox.Services.SDK.Tests/MapAnalyticsTests.cs
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK.Tests/MapAnalyticsTests.cs
@@ -1,0 +1,168 @@
+﻿namespace GISBlox.Services.SDK.Tests
+{
+   [TestClass]
+   public class MapAnalyticsTests
+   {
+      GISBloxClient _client;
+      const string BASE_URL = "https://services.gisblox.com";
+      
+      #region Initialization and cleanup
+
+      [TestInitialize]
+      public void Init()
+      {
+         // Get the service key from the test.runsettings file
+         string serviceKey = Environment.GetEnvironmentVariable("ServiceKey");
+
+         // Create the service client object
+         _client = GISBloxClient.CreateClient(BASE_URL, serviceKey, applicationName: "GISBlox.Services.SDK.Tests");
+      }
+
+      [TestCleanup]
+      public void Cleanup()
+      {
+         _client.Dispose();
+      }
+
+      #endregion
+
+      [TestMethod]
+      public async Task ListTrackedMaps()
+      {
+         var record = await _client.MapAnalytics.ListTrackedMaps();
+
+         Assert.IsNotNull(record);
+         Assert.IsNotNull(record.Maps);
+      }
+
+      [TestMethod]
+      public async Task GetMapEngagement()
+      {
+         string mapId = "7D6C2135-C878-4945-8622-60D3FE9B4BC3";
+         AnalyticsDateRangeEnum dateRange = AnalyticsDateRangeEnum.ThreeWeeks;
+
+         var record = await _client.MapAnalytics.GetMapEngagement(mapId, dateRange);
+
+         Assert.IsNotNull(record, "Response is empty.");
+         Assert.AreEqual(mapId, record.MapId);
+
+         var engagements = record.Engagements;
+         
+         Assert.HasCount(21, engagements);
+      }
+
+      [TestMethod]
+      public async Task GetMapEngagementWithEndDate()
+      {
+         DateTime endDate = DateTime.Parse("2025-11-21");
+         string mapId = "7D6C2135-C878-4945-8622-60D3FE9B4BC3";
+         AnalyticsDateRangeEnum dateRange = AnalyticsDateRangeEnum.ThreeWeeks;
+
+         var record = await _client.MapAnalytics.GetMapEngagement(mapId, dateRange, endDate);
+
+         Assert.IsNotNull(record, "Response is empty.");
+
+         Assert.AreEqual(mapId, record.MapId);
+         Assert.AreEqual(dateRange.ToString(), record.DateRange);
+         Assert.AreEqual(endDate.Add(new TimeSpan(23, 59, 59)), record.EndDate);
+         Assert.AreEqual(endDate.AddDays(-(int)dateRange + 1), record.StartDate);
+         
+         var engagements = record.Engagements;
+
+         Assert.HasCount(21, engagements);
+      }
+
+      [TestMethod]
+      public async Task GetMapKpis()
+      {
+         string mapId = "7D6C2135-C878-4945-8622-60D3FE9B4BC3";
+         AnalyticsDateRangeEnum dateRange = AnalyticsDateRangeEnum.ThreeWeeks;
+
+         var record = await _client.MapAnalytics.GetMapKpis(mapId, dateRange);
+
+         Assert.IsNotNull(record, "Response is empty.");
+         Assert.AreEqual(dateRange.ToString(), record.DateRange);
+
+         var map = record.MapKpis[0];
+
+         Assert.HasCount(4, map.Kpis);
+         Assert.AreEqual(mapId, map.MapId);         
+
+         Assert.IsTrue(map.Kpis.Any(k => k.Name == "Views"), "Views KPI missing.");
+         Assert.IsTrue(map.Kpis.Any(k => k.Name == "Interactions"), "Interactions KPI missing.");
+         Assert.IsTrue(map.Kpis.Any(k => k.Name == "ViewDuration"), "ViewDuration KPI missing.");
+         Assert.IsTrue(map.Kpis.Any(k => k.Name == "ViewDurationAvg"), "ViewDurationAvg KPI missing.");
+      }
+
+      [TestMethod]
+      public async Task GetMapKpisWithEndDate()
+      {
+         DateTime endDate = DateTime.Parse("2025-11-21");
+         string mapId = "7D6C2135-C878-4945-8622-60D3FE9B4BC3";
+         AnalyticsDateRangeEnum dateRange = AnalyticsDateRangeEnum.TwoWeeks;
+
+         var record = await _client.MapAnalytics.GetMapKpis(mapId, dateRange, endDate);
+
+         Assert.IsNotNull(record, "Response is empty.");
+         Assert.AreEqual(dateRange.ToString(), record.DateRange);
+         Assert.AreEqual(endDate.Add(new TimeSpan(23, 59, 59)), record.EndDate);
+         Assert.AreEqual(endDate.AddDays(-(int)dateRange + 1), record.StartDate);
+
+         var map = record.MapKpis[0];
+
+         Assert.HasCount(4, map.Kpis);
+         Assert.AreEqual(mapId, map.MapId);
+
+         Assert.IsTrue(map.Kpis.Any(k => k.Name == "Views"), "Views KPI missing.");
+         Assert.IsTrue(map.Kpis.Any(k => k.Name == "Interactions"), "Interactions KPI missing.");
+         Assert.IsTrue(map.Kpis.Any(k => k.Name == "ViewDuration"), "ViewDuration KPI missing.");
+         Assert.IsTrue(map.Kpis.Any(k => k.Name == "ViewDurationAvg"), "ViewDurationAvg KPI missing.");
+      }
+
+      [TestMethod]
+      public async Task GetMapsKpis()
+      {
+         AnalyticsDateRangeEnum dateRange = AnalyticsDateRangeEnum.TwoWeeks;
+
+         var record = await _client.MapAnalytics.GetMapsKpis(dateRange);
+
+         Assert.IsNotNull(record);
+
+         Assert.AreEqual(dateRange.ToString(), record.DateRange);
+         Assert.IsTrue(record.MapKpis.Any(k => k.Kpis.Count == 4));
+
+         foreach (var map in record.MapKpis)
+         {
+            Assert.IsTrue(map.Kpis.Any(k => k.Name == "Views"), "Views KPI missing.");
+            Assert.IsTrue(map.Kpis.Any(k => k.Name == "Interactions"), "Interactions KPI missing.");
+            Assert.IsTrue(map.Kpis.Any(k => k.Name == "ViewDuration"), "ViewDuration KPI missing.");
+            Assert.IsTrue(map.Kpis.Any(k => k.Name == "ViewDurationAvg"), "ViewDurationAvg KPI missing.");
+         }
+      }
+
+      [TestMethod]
+      public async Task GetMapsKpisWithEndDate()
+      {
+         DateTime endDate = DateTime.Parse("2025-11-21");
+         AnalyticsDateRangeEnum dateRange = AnalyticsDateRangeEnum.TwoWeeks;
+
+         var record = await _client.MapAnalytics.GetMapsKpis(dateRange, endDate);
+
+         Assert.IsNotNull(record);
+
+         Assert.AreEqual(dateRange.ToString(), record.DateRange);
+         Assert.AreEqual(endDate.Add(new TimeSpan(23, 59, 59)), record.EndDate);
+         Assert.AreEqual(endDate.AddDays(-(int)dateRange + 1), record.StartDate);
+         
+         Assert.IsTrue(record.MapKpis.Any(k => k.Kpis.Count == 4));
+
+         foreach (var map in record.MapKpis)
+         {
+            Assert.IsTrue(map.Kpis.Any(k => k.Name == "Views"), "Views KPI missing.");
+            Assert.IsTrue(map.Kpis.Any(k => k.Name == "Interactions"), "Interactions KPI missing.");
+            Assert.IsTrue(map.Kpis.Any(k => k.Name == "ViewDuration"), "ViewDuration KPI missing.");
+            Assert.IsTrue(map.Kpis.Any(k => k.Name == "ViewDurationAvg"), "ViewDurationAvg KPI missing.");
+         }
+      }
+   }
+}

--- a/GISBlox.Services.SDK/GISBlox.Services.SDK/DataLake/DataLakeAPIClient.cs
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK/DataLake/DataLakeAPIClient.cs
@@ -30,15 +30,8 @@ namespace GISBlox.Services.SDK.DataLake
       public async Task<bool> DeleteFile(string fileName, CancellationToken cancellationToken = default)
       {
          var requestUri = $"datalake/delete/{fileName}";
-         try
-         {
-            await HttpDelete(HttpClient, requestUri, null, cancellationToken);
-            return true;
-         }
-         catch (ClientApiException)
-         {
-            throw;
-         }
+         await HttpDelete(HttpClient, requestUri, null, cancellationToken);
+         return true;
       }
 
       /// <summary>        
@@ -51,15 +44,8 @@ namespace GISBlox.Services.SDK.DataLake
       public async Task<bool> DownloadFile(string fileName, string localPath, CancellationToken cancellationToken = default)
       {
          var requestUri = $"datalake/load/{fileName}";
-         try
-         {
-            await DownloadFileToDisk(HttpClient, requestUri, localPath, "application/json", null, cancellationToken);
-            return true;
-         }
-         catch (ClientApiException)
-         {
-            throw;
-         }
+         await DownloadFileToDisk(HttpClient, requestUri, localPath, "application/json", null, cancellationToken);
+         return true;
       }
       
       /// <summary>
@@ -84,15 +70,8 @@ namespace GISBlox.Services.SDK.DataLake
       public async Task<bool> ExportFileAsGeoParquet(string fileName, string localPath, CancellationToken cancellationToken = default)
       {
          var requestUri = $"datalake/export/{fileName}?format=geoparquet";
-         try
-         {
-            await DownloadFileToDisk(HttpClient, requestUri, localPath, "application/octet-stream", null, cancellationToken);
-            return true;
-         }
-         catch (ClientApiException)
-         {
-            throw;
-         }
+         await DownloadFileToDisk(HttpClient, requestUri, localPath, "application/octet-stream", null, cancellationToken);
+         return true;
       }
 
       /// <summary>        
@@ -138,15 +117,8 @@ namespace GISBlox.Services.SDK.DataLake
       public async Task<bool> UploadFile(Stream stream, string fileName, CancellationToken cancellationToken = default)
       {
          var requestUri = $"datalake/save/{fileName}";
-         try
-         {
-            await HttpPost(HttpClient, requestUri, stream, "application/json", null, cancellationToken);
-            return true;
-         }
-         catch (ClientApiException)
-         {
-            throw;
-         }
+         await HttpPost(HttpClient, requestUri, stream, "application/json", null, cancellationToken);
+         return true;
       }
 
       /// <summary>
@@ -159,15 +131,8 @@ namespace GISBlox.Services.SDK.DataLake
       public async Task<bool> UploadFileData(string jsonData, string fileName, CancellationToken cancellationToken = default)
       {
          var requestUri = $"datalake/save/{fileName}";
-         try
-         {
-            await HttpPost(HttpClient, requestUri, jsonData, null, cancellationToken);
-            return true;
-         }
-         catch (ClientApiException)
-         {
-            throw;
-         }
+         await HttpPost(HttpClient, requestUri, jsonData, null, cancellationToken);
+         return true;
       }
    }
 }

--- a/GISBlox.Services.SDK/GISBlox.Services.SDK/GISBlox.Services.SDK.xml
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK/GISBlox.Services.SDK.xml
@@ -607,6 +607,11 @@
             Entry point to the Data Lake API.
             </summary>
         </member>
+        <member name="P:GISBlox.Services.SDK.GISBloxClient.MapAnalytics">
+            <summary>
+            Entry point to the Map Analytics API.
+            </summary>
+        </member>
         <member name="M:GISBlox.Services.SDK.GISBloxClient.Dispose">
             <summary>
             Disposes the GISBloxClient class.
@@ -650,6 +655,95 @@
             </summary>
             <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
             <returns>A List with <see cref="T:GISBlox.Services.SDK.Models.Subscription"/> types.</returns>
+        </member>
+        <member name="T:GISBlox.Services.SDK.MapAnalytics.IMapAnalyticsAPI">
+            <summary>
+            Interface for MapAnalyticsAPI class.
+            </summary>
+        </member>
+        <member name="M:GISBlox.Services.SDK.MapAnalytics.IMapAnalyticsAPI.GetMapEngagement(System.String,GISBlox.Services.SDK.Models.AnalyticsDateRangeEnum,System.Nullable{System.DateTime})">
+            <summary>
+            Gets the engagement metrics for a specific map.
+            </summary>
+            <param name="mapId">The ID of the map.</param>
+            <param name="dateRange">The date range for the engagement data.</param>
+            <param name="endDate">The end date for the engagement data (optional). If not specified, the end date will be set to yesterday.</param>
+            <returns>An engagement record for the specified map.</returns>
+        </member>
+        <member name="M:GISBlox.Services.SDK.MapAnalytics.IMapAnalyticsAPI.GetMapKpis(System.String,GISBlox.Services.SDK.Models.AnalyticsDateRangeEnum,System.Nullable{System.DateTime})">
+            <summary>
+            Gets the KPI data for a specific map.
+            </summary>
+            <param name="mapId">The ID of the map.</param>
+            <param name="dateRange">The date range for the KPI data.</param>
+            <param name="endDate">The end date for the KPI data (optional). If not specified, the end date will be set to yesterday.</param>
+            <returns>A KPI record for the specified map.</returns>
+        </member>
+        <member name="M:GISBlox.Services.SDK.MapAnalytics.IMapAnalyticsAPI.GetMapsKpis(GISBlox.Services.SDK.Models.AnalyticsDateRangeEnum,System.Nullable{System.DateTime})">
+            <summary>
+            Gets the KPI data for every tracked map.
+            </summary>
+            <param name="dateRange">The date range for which to retrieve the KPIs.</param>
+            <param name="endDate">The end date for the KPI data (optional). If not specified, the end date will be set to yesterday.</param>
+            <returns>A KPI record for each map.</returns>
+        </member>
+        <member name="M:GISBlox.Services.SDK.MapAnalytics.IMapAnalyticsAPI.ListTrackedMaps">
+            <summary>
+            Gets a list of maps that are tracked for the customer.
+            </summary>
+            <returns>A customer map record with a list of tracked maps and their IDs.</returns>
+        </member>
+        <member name="T:GISBlox.Services.SDK.MapAnalytics.MapAnalyticsAPIClient">
+            <summary>
+            This class provides methods to interact with the Map Analytics API, providing access to data of tracked maps.
+            </summary>
+            <remarks>
+            Initializes a new instance of the GISBlox.Services.SDK.MapAnalytics.MapAnalyticsAPIClient class.
+            </remarks>
+            <param name="httpClient">The current instance of the HTTPClient class.</param>
+            <param name="cache">The current instance of the MemoryCache class.</param>
+        </member>
+        <member name="M:GISBlox.Services.SDK.MapAnalytics.MapAnalyticsAPIClient.#ctor(System.Net.Http.HttpClient,Microsoft.Extensions.Caching.Memory.IMemoryCache)">
+            <summary>
+            This class provides methods to interact with the Map Analytics API, providing access to data of tracked maps.
+            </summary>
+            <remarks>
+            Initializes a new instance of the GISBlox.Services.SDK.MapAnalytics.MapAnalyticsAPIClient class.
+            </remarks>
+            <param name="httpClient">The current instance of the HTTPClient class.</param>
+            <param name="cache">The current instance of the MemoryCache class.</param>
+        </member>
+        <member name="M:GISBlox.Services.SDK.MapAnalytics.MapAnalyticsAPIClient.GetMapEngagement(System.String,GISBlox.Services.SDK.Models.AnalyticsDateRangeEnum,System.Nullable{System.DateTime})">
+            <summary>
+            Gets the engagement metrics for a specific map.
+            </summary>
+            <param name="mapId">The ID of the map.</param>
+            <param name="dateRange">The date range for the engagement data.</param>
+            <param name="endDate">The end date for the engagement data (optional). If not specified, the end date will be set to yesterday.</param>
+            <returns>An engagement record for the specified map.</returns>
+        </member>
+        <member name="M:GISBlox.Services.SDK.MapAnalytics.MapAnalyticsAPIClient.GetMapKpis(System.String,GISBlox.Services.SDK.Models.AnalyticsDateRangeEnum,System.Nullable{System.DateTime})">
+            <summary>
+            Gets the KPI data for a specific map.
+            </summary>
+            <param name="mapId">The ID of the map.</param>
+            <param name="dateRange">The date range for the KPI data.</param>
+            <param name="endDate">The end date for the KPI data (optional). If not specified, the end date will be set to yesterday.</param>
+            <returns>A KPI record for the specified map.</returns>
+        </member>
+        <member name="M:GISBlox.Services.SDK.MapAnalytics.MapAnalyticsAPIClient.GetMapsKpis(GISBlox.Services.SDK.Models.AnalyticsDateRangeEnum,System.Nullable{System.DateTime})">
+            <summary>
+            Gets the KPI data for every tracked map.
+            </summary>
+            <param name="dateRange">The date range for which to retrieve the KPIs.</param>
+            <param name="endDate">The end date for the KPI data (optional). If not specified, the end date will be set to yesterday.</param>
+            <returns>A KPI record for each map.</returns>
+        </member>
+        <member name="M:GISBlox.Services.SDK.MapAnalytics.MapAnalyticsAPIClient.ListTrackedMaps">
+            <summary>
+            Gets a list of maps that are tracked for the customer.
+            </summary>
+            <returns>A customer map record with a list of tracked maps and their IDs.</returns>
         </member>
         <member name="T:GISBlox.Services.SDK.Models.Subscription">
             <summary>
@@ -899,6 +993,208 @@
             </summary>
             <param name="x">The x-coordinate of the point in RDNew projection (EPSG:28992).</param>
             <param name="y">The y-coordinate of the point in RDNew projection (EPSG:28992).</param>
+        </member>
+        <member name="T:GISBlox.Services.SDK.Models.AnalyticsDateRangeEnum">
+            <summary>
+            Represents the date range for analytics queries.
+            </summary>
+        </member>
+        <member name="F:GISBlox.Services.SDK.Models.AnalyticsDateRangeEnum.OneWeek">
+            <summary>
+            Represents a one-week date range.
+            </summary>
+        </member>
+        <member name="F:GISBlox.Services.SDK.Models.AnalyticsDateRangeEnum.TwoWeeks">
+            <summary>
+            Represents a time span of two weeks.
+            </summary>
+        </member>
+        <member name="F:GISBlox.Services.SDK.Models.AnalyticsDateRangeEnum.ThreeWeeks">
+            <summary>
+            Represents a time span of three weeks.
+            </summary>
+        </member>
+        <member name="F:GISBlox.Services.SDK.Models.AnalyticsDateRangeEnum.OneMonth">
+            <summary>
+            Represents a time span of one month.
+            </summary>
+        </member>
+        <member name="T:GISBlox.Services.SDK.Models.CustomerMap">
+            <summary>
+            Represents a customer map.
+            </summary>
+        </member>
+        <member name="P:GISBlox.Services.SDK.Models.CustomerMap.Id">
+            <summary>
+            The unique identifier for the map.
+            </summary>
+        </member>
+        <member name="P:GISBlox.Services.SDK.Models.CustomerMap.Name">
+            <summary>
+            The name of the map.
+            </summary>
+        </member>
+        <member name="T:GISBlox.Services.SDK.Models.CustomerMapRecord">
+            <summary>
+            Represents the customer maps record containing a list of customer maps.
+            </summary>
+        </member>
+        <member name="P:GISBlox.Services.SDK.Models.CustomerMapRecord.Maps">
+            <summary>
+            A list of customer maps.
+            </summary>
+        </member>
+        <member name="T:GISBlox.Services.SDK.Models.Engagement">
+            <summary>
+            Represents engagement data for a specific map.
+            </summary>
+        </member>
+        <member name="P:GISBlox.Services.SDK.Models.Engagement.SessionDate">
+            <summary>
+            The date of the engagement session.
+            </summary>
+        </member>
+        <member name="P:GISBlox.Services.SDK.Models.Engagement.Views">
+            <summary>
+            The total number of map views on the session date.
+            </summary>
+        </member>
+        <member name="P:GISBlox.Services.SDK.Models.Engagement.ViewDuration">
+            <summary>
+            The total duration of map views in seconds on the session date.
+            </summary>
+        </member>
+        <member name="P:GISBlox.Services.SDK.Models.Engagement.Interactions">
+            <summary>
+            The total amount of interactions with the map on the session date.
+            </summary> 
+        </member>
+        <member name="P:GISBlox.Services.SDK.Models.Engagement.ZoomCount">
+            <summary>
+            The number of times the map was zoomed in or out on the session date.
+            </summary>
+        </member>
+        <member name="P:GISBlox.Services.SDK.Models.Engagement.PanCount">
+            <summary>
+            The number of times the map was panned on the session date.
+            </summary> 
+        </member>
+        <member name="P:GISBlox.Services.SDK.Models.Engagement.MarkerClickCount">
+            <summary>
+            The number of times a map marker has been clicked on the session date.
+            </summary>
+        </member>
+        <member name="T:GISBlox.Services.SDK.Models.EngagementRecord">
+            <summary>
+            Represents the engagement record containing engagement data for a specific map over a defined date range.
+            </summary>
+        </member>
+        <member name="P:GISBlox.Services.SDK.Models.EngagementRecord.MapId">
+            <summary>
+            The unique identifier of the map.
+            </summary>      
+        </member>
+        <member name="P:GISBlox.Services.SDK.Models.EngagementRecord.MapName">
+            <summary>
+            The name of the map.
+            </summary>      
+        </member>
+        <member name="P:GISBlox.Services.SDK.Models.EngagementRecord.DateRange">
+            <summary>
+            The selected date range of the engagement data.
+            </summary>      
+        </member>
+        <member name="P:GISBlox.Services.SDK.Models.EngagementRecord.StartDate">
+            <summary>
+            The start date of the date range.
+            </summary>      
+        </member>
+        <member name="P:GISBlox.Services.SDK.Models.EngagementRecord.EndDate">
+            <summary>
+            The end date of the date range.
+            </summary>      
+        </member>
+        <member name="P:GISBlox.Services.SDK.Models.EngagementRecord.Engagements">
+            <summary>
+            The collection of engagements associated with the specified map.
+            </summary>      
+        </member>
+        <member name="T:GISBlox.Services.SDK.Models.Kpi">
+            <summary>
+            Represents a Key Performance Indicator (KPI).
+            The KPI contains both current and historic values along with trend information.
+            The historic value is typically from the previous comparable period (date range).
+            </summary>
+        </member>
+        <member name="P:GISBlox.Services.SDK.Models.Kpi.Name">
+            <summary>
+            The name of the KPI.
+            </summary>      
+        </member>
+        <member name="P:GISBlox.Services.SDK.Models.Kpi.Value">
+            <summary>
+            The numeric value of the KPI.
+            </summary>      
+        </member>
+        <member name="P:GISBlox.Services.SDK.Models.Kpi.ValuePrev">
+            <summary>
+            The historic numeric value of the KPI in the previous period.
+            </summary>      
+        </member>
+        <member name="P:GISBlox.Services.SDK.Models.Kpi.Trend">
+            <summary>
+            The trend indicator of the KPI (1 for up, -1 for down, 0 for no change).
+            </summary>      
+        </member>
+        <member name="P:GISBlox.Services.SDK.Models.Kpi.DiffPct">
+            <summary>
+            The difference percentage between the current and historic KPI values.
+            </summary>      
+        </member>
+        <member name="T:GISBlox.Services.SDK.Models.MapKpi">
+            <summary>
+            Represents a collection of Key Performance Indicators (KPIs) for a specific map.
+            </summary>
+        </member>
+        <member name="P:GISBlox.Services.SDK.Models.MapKpi.MapId">
+            <summary>
+            The unique identifier of the map.
+            </summary>      
+        </member>
+        <member name="P:GISBlox.Services.SDK.Models.MapKpi.MapName">
+            <summary>
+            The name of the map.
+            </summary>      
+        </member>
+        <member name="P:GISBlox.Services.SDK.Models.MapKpi.Kpis">
+            <summary>
+            A collection of key performance indicators (KPIs) associated with the map.
+            </summary>      
+        </member>
+        <member name="T:GISBlox.Services.SDK.Models.MapKpiRecord">
+            <summary>
+            Represents the map KPI record containing key performance indicators (KPIs) for a specific map over a defined date range.
+            </summary>
+        </member>
+        <member name="P:GISBlox.Services.SDK.Models.MapKpiRecord.DateRange">
+            <summary>
+            The selected date range of the KPI data.
+            </summary>      
+        </member>
+        <member name="P:GISBlox.Services.SDK.Models.MapKpiRecord.StartDate">
+            <summary>
+            The start date of the date range.
+            </summary>      
+        </member>
+        <member name="P:GISBlox.Services.SDK.Models.MapKpiRecord.EndDate">
+            <summary>
+            The end date of the date range.
+            </summary>      
+        </member>
+        <member name="P:GISBlox.Services.SDK.Models.MapKpiRecord.MapKpis">
+            <summary>
+            The collection of key performance indicators (KPIs) associated with the specified map.
+            </summary>      
         </member>
         <member name="T:GISBlox.Services.SDK.Models.BoundingBox">
             <summary>

--- a/GISBlox.Services.SDK/GISBlox.Services.SDK/GISBloxClient.cs
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK/GISBloxClient.cs
@@ -5,6 +5,7 @@
 using GISBlox.Services.SDK.Conversion;
 using GISBlox.Services.SDK.DataLake;
 using GISBlox.Services.SDK.Info;
+using GISBlox.Services.SDK.MapAnalytics;
 using GISBlox.Services.SDK.PostalCodes;
 using GISBlox.Services.SDK.Projection;
 using Microsoft.Extensions.Caching.Memory;
@@ -17,108 +18,115 @@ using System.Reflection;
 
 namespace GISBlox.Services.SDK
 {
-    /// <summary>
-    /// The main entry point for every available GISBlox Location Services method.
-    /// </summary>
-    public class GISBloxClient : IDisposable
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="GISBloxClient"/> class.
-        /// </summary>
-        /// <param name="baseUrl">The base URL of the services API, i.e. https://services.gisblox.com</param>
-        /// <param name="serviceKey">The service key.</param>
-        /// <param name="timeoutSeconds">The timeout in seconds for the http requests.</param>
-        /// <param name="applicationName">Optional name (tag) of the calling application.</param>
-        protected GISBloxClient(string baseUrl, string serviceKey, long timeoutSeconds = 30, string applicationName = null)
-        {
-            var apiUrl = new Uri(new Uri(baseUrl), "v1/");
+   /// <summary>
+   /// The main entry point for every available GISBlox Location Services method.
+   /// </summary>
+   public class GISBloxClient : IDisposable
+   {
+      /// <summary>
+      /// Initializes a new instance of the <see cref="GISBloxClient"/> class.
+      /// </summary>
+      /// <param name="baseUrl">The base URL of the services API, i.e. https://services.gisblox.com</param>
+      /// <param name="serviceKey">The service key.</param>
+      /// <param name="timeoutSeconds">The timeout in seconds for the http requests.</param>
+      /// <param name="applicationName">Optional name (tag) of the calling application.</param>
+      protected GISBloxClient(string baseUrl, string serviceKey, long timeoutSeconds = 30, string applicationName = null)
+      {
+         var apiUrl = new Uri(new Uri(baseUrl), "v1/");
 
-            var handler = new HttpClientHandler
-            {
-                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
-            };
+         var handler = new HttpClientHandler
+         {
+            AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+         };
 
-            var httpClient = new HttpClient(handler, false)
-            {
-                BaseAddress = apiUrl,
-                Timeout = TimeSpan.FromSeconds(timeoutSeconds)
-            };
+         var httpClient = new HttpClient(handler, false)
+         {
+            BaseAddress = apiUrl,
+            Timeout = TimeSpan.FromSeconds(timeoutSeconds)
+         };
 
-            httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            httpClient.DefaultRequestHeaders.AcceptEncoding.Add(new StringWithQualityHeaderValue("gzip"));
-            httpClient.DefaultRequestHeaders.Add("X-Service-Key", serviceKey);
-            httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("gisblox-services-sdk", GetAssemblyFileVersion()));
+         httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+         httpClient.DefaultRequestHeaders.AcceptEncoding.Add(new StringWithQualityHeaderValue("gzip"));
+         httpClient.DefaultRequestHeaders.Add("X-Service-Key", serviceKey);
+         httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("gisblox-services-sdk", GetAssemblyFileVersion()));
 
-            if (!string.IsNullOrWhiteSpace(applicationName))
-            {                
-                httpClient.DefaultRequestHeaders.Add("X-Application-Name", applicationName);
-            }
+         if (!string.IsNullOrWhiteSpace(applicationName))
+         {
+            httpClient.DefaultRequestHeaders.Add("X-Application-Name", applicationName);
+         }
 
-            IMemoryCache cache = new MemoryCache(new MemoryCacheOptions());
+         IMemoryCache cache = new MemoryCache(new MemoryCacheOptions());
 
-            this.DataLake = new DataLakeAPIClient(httpClient, cache);
-            this.PostalCodes = new PostalCodesAPIClient(httpClient, cache);
-            this.Projection = new ProjectionAPIClient(httpClient, cache);
-            this.Conversion = new ConversionAPIClient(httpClient, cache);
-            this.Info = new InfoAPIClient(httpClient, cache);            
-        }
+         this.DataLake = new DataLakeAPIClient(httpClient, cache);
+         this.PostalCodes = new PostalCodesAPIClient(httpClient, cache);
+         this.Projection = new ProjectionAPIClient(httpClient, cache);
+         this.Conversion = new ConversionAPIClient(httpClient, cache);         
+         this.MapAnalytics = new MapAnalyticsAPIClient(httpClient, cache);
+         this.Info = new InfoAPIClient(httpClient, cache);
+      }
 
-        /// <summary>
-        /// Create the client object with specified base URL, service key and timeout.
-        /// </summary>
-        /// <param name="baseUrl">Base URL for the GISBlox Services resource, i.e. https://services.gisblox.com</param>
-        /// <param name="serviceKey">The service key.</param>
-        /// <param name="timeoutSeconds">Web request time out in seconds</param>
-        /// <param name="applicationName">Optional name (tag) of the calling application.</param>
-        /// <returns></returns>
-        public static GISBloxClient CreateClient(string baseUrl, string serviceKey, long timeoutSeconds = 30, string applicationName = null)
-        {
-            return new GISBloxClient(baseUrl, serviceKey, timeoutSeconds, applicationName);
-        }
+      /// <summary>
+      /// Create the client object with specified base URL, service key and timeout.
+      /// </summary>
+      /// <param name="baseUrl">Base URL for the GISBlox Services resource, i.e. https://services.gisblox.com</param>
+      /// <param name="serviceKey">The service key.</param>
+      /// <param name="timeoutSeconds">Web request time out in seconds</param>
+      /// <param name="applicationName">Optional name (tag) of the calling application.</param>
+      /// <returns></returns>
+      public static GISBloxClient CreateClient(string baseUrl, string serviceKey, long timeoutSeconds = 30, string applicationName = null)
+      {
+         return new GISBloxClient(baseUrl, serviceKey, timeoutSeconds, applicationName);
+      }
 
-        /// <summary>
-        /// Entry point to the Postal Codes API.
-        /// </summary>
-        public IPostalCodesAPI PostalCodes { get; }
+      /// <summary>
+      /// Entry point to the Postal Codes API.
+      /// </summary>
+      public IPostalCodesAPI PostalCodes { get; }
 
-        /// <summary>
-        /// Entry point to the Projection API.
-        /// </summary>
-        public IProjectionAPI Projection { get; }
+      /// <summary>
+      /// Entry point to the Projection API.
+      /// </summary>
+      public IProjectionAPI Projection { get; }
 
-        /// <summary>
-        /// Entry point to the Conversion API.
-        /// </summary>
-        public IConversionAPI Conversion { get; }
+      /// <summary>
+      /// Entry point to the Conversion API.
+      /// </summary>
+      public IConversionAPI Conversion { get; }
 
-        /// <summary>
-        /// Entry point to the Info API.
-        /// </summary>
-        public IInfoAPI Info { get; }
+      /// <summary>
+      /// Entry point to the Info API.
+      /// </summary>
+      public IInfoAPI Info { get; }
 
-        /// <summary>
-        /// Entry point to the Data Lake API.
-        /// </summary>
-        public IDataLakeAPI DataLake { get; }
+      /// <summary>
+      /// Entry point to the Data Lake API.
+      /// </summary>
+      public IDataLakeAPI DataLake { get; }
 
-        /// <summary>
-        /// Disposes the GISBloxClient class.
-        /// </summary>
-        public void Dispose()
-        {            
-            DataLake?.Dispose();
-            PostalCodes?.Dispose();
-            Projection?.Dispose();
-            Conversion?.Dispose();
-            Info?.Dispose();
-            GC.SuppressFinalize(this);
-        }
+      /// <summary>
+      /// Entry point to the Map Analytics API.
+      /// </summary>
+      public IMapAnalyticsAPI MapAnalytics { get; }
 
-        private static string GetAssemblyFileVersion()
-        {
-            Assembly assembly = Assembly.GetExecutingAssembly();
-            FileVersionInfo fileVersion = FileVersionInfo.GetVersionInfo(assembly.Location);
-            return fileVersion.FileVersion;
-        }
-    }
+      /// <summary>
+      /// Disposes the GISBloxClient class.
+      /// </summary>
+      public void Dispose()
+      {
+         DataLake?.Dispose();
+         PostalCodes?.Dispose();
+         Projection?.Dispose();
+         Conversion?.Dispose();         
+         MapAnalytics?.Dispose();
+         Info?.Dispose();
+         GC.SuppressFinalize(this);
+      }
+
+      private static string GetAssemblyFileVersion()
+      {
+         Assembly assembly = Assembly.GetExecutingAssembly();
+         FileVersionInfo fileVersion = FileVersionInfo.GetVersionInfo(assembly.Location);
+         return fileVersion.FileVersion;
+      }
+   }
 }

--- a/GISBlox.Services.SDK/GISBlox.Services.SDK/MapAnalytics/IMapAnalyticsAPI.cs
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK/MapAnalytics/IMapAnalyticsAPI.cs
@@ -1,0 +1,48 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Bartels Online.  All rights reserved.
+// ------------------------------------------------------------
+
+using GISBlox.Services.SDK.Models;
+using System;
+using System.Threading.Tasks;
+
+namespace GISBlox.Services.SDK.MapAnalytics
+{
+   /// <summary>
+   /// Interface for MapAnalyticsAPI class.
+   /// </summary>
+   public interface IMapAnalyticsAPI : IDisposable
+   {
+      /// <summary>
+      /// Gets the engagement metrics for a specific map.
+      /// </summary>
+      /// <param name="mapId">The ID of the map.</param>
+      /// <param name="dateRange">The date range for the engagement data.</param>
+      /// <param name="endDate">The end date for the engagement data (optional). If not specified, the end date will be set to yesterday.</param>
+      /// <returns>An engagement record for the specified map.</returns>
+      Task<EngagementRecord> GetMapEngagement(string mapId, AnalyticsDateRangeEnum dateRange, DateTime? endDate = null);
+
+      /// <summary>
+      /// Gets the KPI data for a specific map.
+      /// </summary>
+      /// <param name="mapId">The ID of the map.</param>
+      /// <param name="dateRange">The date range for the KPI data.</param>
+      /// <param name="endDate">The end date for the KPI data (optional). If not specified, the end date will be set to yesterday.</param>
+      /// <returns>A KPI record for the specified map.</returns>
+      Task<MapKpiRecord> GetMapKpis(string mapId, AnalyticsDateRangeEnum dateRange, DateTime? endDate = null);
+
+      /// <summary>
+      /// Gets the KPI data for every tracked map.
+      /// </summary>
+      /// <param name="dateRange">The date range for which to retrieve the KPIs.</param>
+      /// <param name="endDate">The end date for the KPI data (optional). If not specified, the end date will be set to yesterday.</param>
+      /// <returns>A KPI record for each map.</returns>
+      Task<MapKpiRecord> GetMapsKpis(AnalyticsDateRangeEnum dateRange, DateTime? endDate = null);
+
+      /// <summary>
+      /// Gets a list of maps that are tracked for the customer.
+      /// </summary>
+      /// <returns>A customer map record with a list of tracked maps and their IDs.</returns>
+      Task<CustomerMapRecord> ListTrackedMaps();
+   }
+}

--- a/GISBlox.Services.SDK/GISBlox.Services.SDK/MapAnalytics/MapAnalyticsAPIClient.cs
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK/MapAnalytics/MapAnalyticsAPIClient.cs
@@ -1,0 +1,84 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Bartels Online.  All rights reserved.
+// ------------------------------------------------------------
+
+using GISBlox.Services.SDK.Models;
+using Microsoft.Extensions.Caching.Memory;
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GISBlox.Services.SDK.MapAnalytics
+{
+   /// <summary>
+   /// This class provides methods to interact with the Map Analytics API, providing access to data of tracked maps.
+   /// </summary>
+   /// <remarks>
+   /// Initializes a new instance of the GISBlox.Services.SDK.MapAnalytics.MapAnalyticsAPIClient class.
+   /// </remarks>
+   /// <param name="httpClient">The current instance of the HTTPClient class.</param>
+   /// <param name="cache">The current instance of the MemoryCache class.</param>
+   public class MapAnalyticsAPIClient(HttpClient httpClient, IMemoryCache cache) : ApiClient(httpClient, cache), IMapAnalyticsAPI
+   {
+      /// <summary>
+      /// Gets the engagement metrics for a specific map.
+      /// </summary>
+      /// <param name="mapId">The ID of the map.</param>
+      /// <param name="dateRange">The date range for the engagement data.</param>
+      /// <param name="endDate">The end date for the engagement data (optional). If not specified, the end date will be set to yesterday.</param>
+      /// <returns>An engagement record for the specified map.</returns>
+      public async Task<EngagementRecord> GetMapEngagement(string mapId, AnalyticsDateRangeEnum dateRange, DateTime? endDate = null)
+      {
+         var sb = new StringBuilder($"mapanalytics/engagement/{mapId}?range={(int)dateRange}");
+         if (endDate.HasValue)
+            sb.Append("&day=").Append(endDate.Value.ToString("yyyy-MM-dd"));
+
+         var requestUri = sb.ToString();
+         return await HttpGet<EngagementRecord>(HttpClient, cache, requestUri);
+      }
+
+      /// <summary>
+      /// Gets the KPI data for a specific map.
+      /// </summary>
+      /// <param name="mapId">The ID of the map.</param>
+      /// <param name="dateRange">The date range for the KPI data.</param>
+      /// <param name="endDate">The end date for the KPI data (optional). If not specified, the end date will be set to yesterday.</param>
+      /// <returns>A KPI record for the specified map.</returns>
+      public async Task<MapKpiRecord> GetMapKpis(string mapId, AnalyticsDateRangeEnum dateRange, DateTime? endDate = null)
+      {
+         var sb = new StringBuilder($"mapanalytics/kpis/{mapId}?range={(int)dateRange}");
+         if (endDate.HasValue)
+            sb.Append("&day=").Append(endDate.Value.ToString("yyyy-MM-dd"));
+
+         var requestUri = sb.ToString();
+         return await HttpGet<MapKpiRecord>(HttpClient, cache, requestUri);
+      }
+
+      /// <summary>
+      /// Gets the KPI data for every tracked map.
+      /// </summary>
+      /// <param name="dateRange">The date range for which to retrieve the KPIs.</param>
+      /// <param name="endDate">The end date for the KPI data (optional). If not specified, the end date will be set to yesterday.</param>
+      /// <returns>A KPI record for each map.</returns>
+      public async Task<MapKpiRecord> GetMapsKpis(AnalyticsDateRangeEnum dateRange, DateTime? endDate = null)
+      {
+         var sb = new StringBuilder($"mapanalytics/kpis?range={(int)dateRange}");
+         if (endDate.HasValue)
+            sb.Append("&day=").Append(endDate.Value.ToString("yyyy-MM-dd"));
+
+         var requestUri = sb.ToString();
+         return await HttpGet<MapKpiRecord>(HttpClient, cache, requestUri);
+      }
+
+      /// <summary>
+      /// Gets a list of maps that are tracked for the customer.
+      /// </summary>
+      /// <returns>A customer map record with a list of tracked maps and their IDs.</returns>
+      public async Task<CustomerMapRecord> ListTrackedMaps()
+      {
+         const string requestUri = "mapanalytics/list";
+         return await HttpGet<CustomerMapRecord>(HttpClient, cache, requestUri);
+      }
+   }
+}

--- a/GISBlox.Services.SDK/GISBlox.Services.SDK/Models/MapAnalytics/AnalyticsDateRangeEnum.cs
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK/Models/MapAnalytics/AnalyticsDateRangeEnum.cs
@@ -1,0 +1,39 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Bartels Online.  All rights reserved.
+// ------------------------------------------------------------
+
+using System.ComponentModel;
+
+namespace GISBlox.Services.SDK.Models
+{
+   /// <summary>
+   /// Represents the date range for analytics queries.
+   /// </summary>
+   public enum AnalyticsDateRangeEnum
+   {
+
+      /// <summary>
+      /// Represents a one-week date range.
+      /// </summary>
+      [Description("Represents a one-week date range.")]
+      OneWeek = 7,
+
+      /// <summary>
+      /// Represents a time span of two weeks.
+      /// </summary>
+      [Description("Represents a time span of two weeks.")]
+      TwoWeeks = 14,
+
+      /// <summary>
+      /// Represents a time span of three weeks.
+      /// </summary>
+      [Description("Represents a time span of three weeks.")]
+      ThreeWeeks = 21,
+
+      /// <summary>
+      /// Represents a time span of one month.
+      /// </summary>
+      [Description("Represents a time span of one month.")]
+      OneMonth = 31
+   };
+}

--- a/GISBlox.Services.SDK/GISBlox.Services.SDK/Models/MapAnalytics/CustomerMap.cs
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK/Models/MapAnalytics/CustomerMap.cs
@@ -1,0 +1,24 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Bartels Online.  All rights reserved.
+// ------------------------------------------------------------
+
+using System;
+
+namespace GISBlox.Services.SDK.Models
+{
+   /// <summary>
+   /// Represents a customer map.
+   /// </summary>
+   public class CustomerMap
+   {
+      /// <summary>
+      /// The unique identifier for the map.
+      /// </summary>
+      public Guid Id { get; set; }
+
+      /// <summary>
+      /// The name of the map.
+      /// </summary>
+      public string Name { get; set; }
+   }
+}

--- a/GISBlox.Services.SDK/GISBlox.Services.SDK/Models/MapAnalytics/CustomerMapRecord.cs
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK/Models/MapAnalytics/CustomerMapRecord.cs
@@ -1,0 +1,19 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Bartels Online.  All rights reserved.
+// ------------------------------------------------------------
+
+using System.Collections.Generic;
+
+namespace GISBlox.Services.SDK.Models
+{
+   /// <summary>
+   /// Represents the customer maps record containing a list of customer maps.
+   /// </summary>
+   public class CustomerMapRecord
+   {
+      /// <summary>
+      /// A list of customer maps.
+      /// </summary>
+      public List<CustomerMap> Maps { get; set; }
+   }
+}

--- a/GISBlox.Services.SDK/GISBlox.Services.SDK/Models/MapAnalytics/Engagement.cs
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK/Models/MapAnalytics/Engagement.cs
@@ -1,0 +1,49 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Bartels Online.  All rights reserved.
+// ------------------------------------------------------------
+
+using System;
+
+namespace GISBlox.Services.SDK.Models
+{
+   /// <summary>
+   /// Represents engagement data for a specific map.
+   /// </summary>
+   public class Engagement
+   {
+      /// <summary>
+      /// The date of the engagement session.
+      /// </summary>
+      public DateTime SessionDate { get; set; }
+
+      /// <summary>
+      /// The total number of map views on the session date.
+      /// </summary>
+      public int Views { get; set; }
+
+      /// <summary>
+      /// The total duration of map views in seconds on the session date.
+      /// </summary>
+      public int ViewDuration { get; set; }
+
+      /// <summary>
+      /// The total amount of interactions with the map on the session date.
+      /// </summary> 
+      public int Interactions { get; set; }
+
+      /// <summary>
+      /// The number of times the map was zoomed in or out on the session date.
+      /// </summary>
+      public int ZoomCount { get; set; }
+
+      /// <summary>
+      /// The number of times the map was panned on the session date.
+      /// </summary> 
+      public int PanCount { get; set; }
+
+      /// <summary>
+      /// The number of times a map marker has been clicked on the session date.
+      /// </summary>
+      public int MarkerClickCount { get; set; }
+   }
+}

--- a/GISBlox.Services.SDK/GISBlox.Services.SDK/Models/MapAnalytics/EngagementRecord.cs
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK/Models/MapAnalytics/EngagementRecord.cs
@@ -1,0 +1,45 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Bartels Online.  All rights reserved.
+// ------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace GISBlox.Services.SDK.Models
+{
+   /// <summary>
+   /// Represents the engagement record containing engagement data for a specific map over a defined date range.
+   /// </summary>
+   public class EngagementRecord
+   {
+      /// <summary>
+      /// The unique identifier of the map.
+      /// </summary>      
+      public string MapId { get; set; }
+
+      /// <summary>
+      /// The name of the map.
+      /// </summary>      
+      public string MapName { get; set; }
+
+      /// <summary>
+      /// The selected date range of the engagement data.
+      /// </summary>      
+      public string DateRange { get; set; }
+
+      /// <summary>
+      /// The start date of the date range.
+      /// </summary>      
+      public DateTime StartDate { get; set; }
+
+      /// <summary>
+      /// The end date of the date range.
+      /// </summary>      
+      public DateTime EndDate { get; set; }
+
+      /// <summary>
+      /// The collection of engagements associated with the specified map.
+      /// </summary>      
+      public List<Engagement> Engagements { get; set; }
+   }
+}

--- a/GISBlox.Services.SDK/GISBlox.Services.SDK/Models/MapAnalytics/Kpi.cs
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK/Models/MapAnalytics/Kpi.cs
@@ -1,0 +1,39 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Bartels Online.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace GISBlox.Services.SDK.Models
+{
+   /// <summary>
+   /// Represents a Key Performance Indicator (KPI).
+   /// The KPI contains both current and historic values along with trend information.
+   /// The historic value is typically from the previous comparable period (date range).
+   /// </summary>
+   public class Kpi
+   {
+      /// <summary>
+      /// The name of the KPI.
+      /// </summary>      
+      public string Name { get; set; }
+
+      /// <summary>
+      /// The numeric value of the KPI.
+      /// </summary>      
+      public decimal Value { get; set; }
+
+      /// <summary>
+      /// The historic numeric value of the KPI in the previous period.
+      /// </summary>      
+      public decimal ValuePrev { get; set; }
+
+      /// <summary>
+      /// The trend indicator of the KPI (1 for up, -1 for down, 0 for no change).
+      /// </summary>      
+      public int Trend { get; set; }
+
+      /// <summary>
+      /// The difference percentage between the current and historic KPI values.
+      /// </summary>      
+      public int DiffPct { get; set; }
+   }
+}

--- a/GISBlox.Services.SDK/GISBlox.Services.SDK/Models/MapAnalytics/MapKpi.cs
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK/Models/MapAnalytics/MapKpi.cs
@@ -1,0 +1,29 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Bartels Online.  All rights reserved.
+// ------------------------------------------------------------
+
+using System.Collections.Generic;
+
+namespace GISBlox.Services.SDK.Models
+{
+   /// <summary>
+   /// Represents a collection of Key Performance Indicators (KPIs) for a specific map.
+   /// </summary>
+   public class MapKpi
+   {
+      /// <summary>
+      /// The unique identifier of the map.
+      /// </summary>      
+      public string MapId { get; set; }
+
+      /// <summary>
+      /// The name of the map.
+      /// </summary>      
+      public string MapName { get; set; }
+
+      /// <summary>
+      /// A collection of key performance indicators (KPIs) associated with the map.
+      /// </summary>      
+      public List<Kpi> Kpis { get; set; }
+   }
+}

--- a/GISBlox.Services.SDK/GISBlox.Services.SDK/Models/MapAnalytics/MapKpiRecord.cs
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK/Models/MapAnalytics/MapKpiRecord.cs
@@ -1,0 +1,35 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Bartels Online.  All rights reserved.
+// ------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace GISBlox.Services.SDK.Models
+{
+   /// <summary>
+   /// Represents the map KPI record containing key performance indicators (KPIs) for a specific map over a defined date range.
+   /// </summary>
+   public class MapKpiRecord
+   {
+      /// <summary>
+      /// The selected date range of the KPI data.
+      /// </summary>      
+      public string DateRange { get; set; }
+
+      /// <summary>
+      /// The start date of the date range.
+      /// </summary>      
+      public DateTime StartDate { get; set; }
+
+      /// <summary>
+      /// The end date of the date range.
+      /// </summary>      
+      public DateTime EndDate { get; set; }
+
+      /// <summary>
+      /// The collection of key performance indicators (KPIs) associated with the specified map.
+      /// </summary>      
+      public List<MapKpi> MapKpis { get; set; }
+   }
+}

--- a/README.md
+++ b/README.md
@@ -22,11 +22,24 @@ This SDK enables applications to connect to the [GISBlox Services API](https://s
 
 It supports the following Location Services:
 
-* Reproject [WGS84](https://en.wikipedia.org/wiki/World_Geodetic_System#WGS84) coordinates to [Rijksdriehoeksstelsel](https://nl.wikipedia.org/wiki/Rijksdriehoeksco%C3%B6rdinaten) (RDNew) locations, and vice versa
-* Convert [WKB](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry#Well-known_binary) and [WKT](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry) geometry objects into [GeoJson](https://en.wikipedia.org/wiki/GeoJSON), and vice versa
-* Work with Dutch postal codes (used by [ZipChat Copilot](https://www.gisblox.com/zipchat-copilot))
-* Access the GISBlox GeoJson Data Lake
-* Retrieve subscription information
+#### Conversion
+  * Convert [WKB](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry#Well-known_binary) and [WKT](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry) geometry objects into [GeoJson](https://en.wikipedia.org/wiki/GeoJSON), and vice versa. 
+  Supports both single-shot conversions, as well as batch processing of large collections.
+
+#### Data Lake
+  * Access the GISBlox GeoJson Data Lake: upload and manage your GeoJson datasets in the cloud. Supports exporting to modern data formats, such as GeoParquet.
+
+#### Info
+  * Quickly retrieve an overview of your subscriptions and their details.
+
+#### Map Analytics
+  * Analyze user behavior on interactive maps (see [Map Analytics](https://www.gisblox.com/map-analytics)) to provide clarity on engagement and map usage.
+
+#### Postal codes
+  * Query and visualize Dutch postal codes (as used by [ZipChat Copilot](https://www.gisblox.com/zipchat-copilot)) to turn raw postal code data into meaningful insights for regional analysis and decision-making.
+
+#### Projection
+  * Project [WGS84](https://en.wikipedia.org/wiki/World_Geodetic_System#WGS84) coordinates to [Rijksdriehoeksstelsel](https://nl.wikipedia.org/wiki/Rijksdriehoeksco%C3%B6rdinaten) (RDNew) locations, and vice versa. Includes batch processing capabilities. 
 
 To get no-code access to the GISBlox Services API from the command-line, you can use the [GISBlox Services CLI](https://github.com/GISBlox/gisblox-services-cli).
 
@@ -39,6 +52,8 @@ To generate a service key:
 2. Navigate to your [Subscriptions Dashboard](https://account.gisblox.com/profiel/abonnementen)
 3. Click the `Add` button and select the **free** subscription to the **GISBlox Location Services** in the dropdown.
 4. Once subscribed, click the **Location Services** tile and copy the service key from the information panel.
+
+Based on your requirements, you may need to add additional subscriptions to your account.
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -16,11 +16,9 @@
 
 <hr>
 
-## Introduction
+## 🧑‍💻 Introduction
 
-This SDK enables applications to connect to the [GISBlox Services API](https://services.gisblox.com/). 
-
-It supports the following Location Services:
+This SDK enables applications to connect to the [GISBlox Services API](https://services.gisblox.com/). It supports the following Location Services:
 
 #### Conversion
   * Convert [WKB](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry#Well-known_binary) and [WKT](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry) geometry objects into [GeoJson](https://en.wikipedia.org/wiki/GeoJSON), and vice versa. 


### PR DESCRIPTION
#### PR Summary
This pull request introduces the `Map Analytics` API to the SDK, enabling analysis of user behavior on interactive maps, and includes code cleanup for improved maintainability.  
- **`GISBloxClient`**: Added `MapAnalytics` as a new entry point and updated `Dispose` method.  
- **`MapAnalyticsAPIClient` and `IMapAnalyticsAPI`**: Implemented methods for retrieving engagement metrics, KPIs, and tracked maps.  
- **`DataLakeAPIClient`**: Removed redundant `try-catch` blocks in file operations.  
- **New models**: Added `AnalyticsDateRangeEnum`, `CustomerMap`, `Engagement`, `Kpi`, and related record classes.  
- **`MapAnalyticsTests`**: Added unit tests for `MapAnalytics` API functionality.  
