### PR TITLE
Add CancellationToken support to MapAnalytics methods

### DIFF
--- a/GISBlox.Services.SDK/GISBlox.Services.SDK.Tests/MapAnalyticsTests.cs
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK.Tests/MapAnalyticsTests.cs
@@ -29,7 +29,7 @@
       [TestMethod]
       public async Task ListTrackedMaps()
       {
-         var record = await _client.MapAnalytics.ListTrackedMaps();
+         var record = await _client.MapAnalytics.ListTrackedMaps(CancellationToken.None);
 
          Assert.IsNotNull(record);
          Assert.IsNotNull(record.Maps);
@@ -41,7 +41,7 @@
          string mapId = "7D6C2135-C878-4945-8622-60D3FE9B4BC3";
          AnalyticsDateRangeEnum dateRange = AnalyticsDateRangeEnum.ThreeWeeks;
 
-         var record = await _client.MapAnalytics.GetMapEngagement(mapId, dateRange);
+         var record = await _client.MapAnalytics.GetMapEngagement(mapId, dateRange, null, CancellationToken.None);
 
          Assert.IsNotNull(record, "Response is empty.");
          Assert.AreEqual(mapId, record.MapId);
@@ -58,7 +58,7 @@
          string mapId = "7D6C2135-C878-4945-8622-60D3FE9B4BC3";
          AnalyticsDateRangeEnum dateRange = AnalyticsDateRangeEnum.ThreeWeeks;
 
-         var record = await _client.MapAnalytics.GetMapEngagement(mapId, dateRange, endDate);
+         var record = await _client.MapAnalytics.GetMapEngagement(mapId, dateRange, endDate, CancellationToken.None);
 
          Assert.IsNotNull(record, "Response is empty.");
 
@@ -78,7 +78,7 @@
          string mapId = "7D6C2135-C878-4945-8622-60D3FE9B4BC3";
          AnalyticsDateRangeEnum dateRange = AnalyticsDateRangeEnum.ThreeWeeks;
 
-         var record = await _client.MapAnalytics.GetMapKpis(mapId, dateRange);
+         var record = await _client.MapAnalytics.GetMapKpis(mapId, dateRange, null, CancellationToken.None);
 
          Assert.IsNotNull(record, "Response is empty.");
          Assert.AreEqual(dateRange.ToString(), record.DateRange);
@@ -101,7 +101,7 @@
          string mapId = "7D6C2135-C878-4945-8622-60D3FE9B4BC3";
          AnalyticsDateRangeEnum dateRange = AnalyticsDateRangeEnum.TwoWeeks;
 
-         var record = await _client.MapAnalytics.GetMapKpis(mapId, dateRange, endDate);
+         var record = await _client.MapAnalytics.GetMapKpis(mapId, dateRange, endDate, CancellationToken.None);
 
          Assert.IsNotNull(record, "Response is empty.");
          Assert.AreEqual(dateRange.ToString(), record.DateRange);
@@ -124,7 +124,7 @@
       {
          AnalyticsDateRangeEnum dateRange = AnalyticsDateRangeEnum.TwoWeeks;
 
-         var record = await _client.MapAnalytics.GetMapsKpis(dateRange);
+         var record = await _client.MapAnalytics.GetMapsKpis(dateRange, null, CancellationToken.None);
 
          Assert.IsNotNull(record);
 
@@ -146,7 +146,7 @@
          DateTime endDate = DateTime.Parse("2025-11-21");
          AnalyticsDateRangeEnum dateRange = AnalyticsDateRangeEnum.TwoWeeks;
 
-         var record = await _client.MapAnalytics.GetMapsKpis(dateRange, endDate);
+         var record = await _client.MapAnalytics.GetMapsKpis(dateRange, endDate, CancellationToken.None);
 
          Assert.IsNotNull(record);
 

--- a/GISBlox.Services.SDK/GISBlox.Services.SDK/GISBlox.Services.SDK.csproj
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK/GISBlox.Services.SDK.csproj
@@ -9,7 +9,7 @@
     <RepositoryUrl>https://github.com/GISBlox/gisblox-services-sdk</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>GISBlox</PackageTags>
-    <Version>2.6.0</Version>
+    <Version>2.6.1</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>Key.snk.pfx</AssemblyOriginatorKeyFile>

--- a/GISBlox.Services.SDK/GISBlox.Services.SDK/GISBlox.Services.SDK.xml
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK/GISBlox.Services.SDK.xml
@@ -661,36 +661,40 @@
             Interface for MapAnalyticsAPI class.
             </summary>
         </member>
-        <member name="M:GISBlox.Services.SDK.MapAnalytics.IMapAnalyticsAPI.GetMapEngagement(System.String,GISBlox.Services.SDK.Models.AnalyticsDateRangeEnum,System.Nullable{System.DateTime})">
+        <member name="M:GISBlox.Services.SDK.MapAnalytics.IMapAnalyticsAPI.GetMapEngagement(System.String,GISBlox.Services.SDK.Models.AnalyticsDateRangeEnum,System.Nullable{System.DateTime},System.Threading.CancellationToken)">
             <summary>
             Gets the engagement metrics for a specific map.
             </summary>
             <param name="mapId">The ID of the map.</param>
             <param name="dateRange">The date range for the engagement data.</param>
             <param name="endDate">The end date for the engagement data (optional). If not specified, the end date will be set to yesterday.</param>
+            <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
             <returns>An engagement record for the specified map.</returns>
         </member>
-        <member name="M:GISBlox.Services.SDK.MapAnalytics.IMapAnalyticsAPI.GetMapKpis(System.String,GISBlox.Services.SDK.Models.AnalyticsDateRangeEnum,System.Nullable{System.DateTime})">
+        <member name="M:GISBlox.Services.SDK.MapAnalytics.IMapAnalyticsAPI.GetMapKpis(System.String,GISBlox.Services.SDK.Models.AnalyticsDateRangeEnum,System.Nullable{System.DateTime},System.Threading.CancellationToken)">
             <summary>
             Gets the KPI data for a specific map.
             </summary>
             <param name="mapId">The ID of the map.</param>
             <param name="dateRange">The date range for the KPI data.</param>
             <param name="endDate">The end date for the KPI data (optional). If not specified, the end date will be set to yesterday.</param>
+            <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
             <returns>A KPI record for the specified map.</returns>
         </member>
-        <member name="M:GISBlox.Services.SDK.MapAnalytics.IMapAnalyticsAPI.GetMapsKpis(GISBlox.Services.SDK.Models.AnalyticsDateRangeEnum,System.Nullable{System.DateTime})">
+        <member name="M:GISBlox.Services.SDK.MapAnalytics.IMapAnalyticsAPI.GetMapsKpis(GISBlox.Services.SDK.Models.AnalyticsDateRangeEnum,System.Nullable{System.DateTime},System.Threading.CancellationToken)">
             <summary>
             Gets the KPI data for every tracked map.
             </summary>
             <param name="dateRange">The date range for which to retrieve the KPIs.</param>
             <param name="endDate">The end date for the KPI data (optional). If not specified, the end date will be set to yesterday.</param>
+            <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
             <returns>A KPI record for each map.</returns>
         </member>
-        <member name="M:GISBlox.Services.SDK.MapAnalytics.IMapAnalyticsAPI.ListTrackedMaps">
+        <member name="M:GISBlox.Services.SDK.MapAnalytics.IMapAnalyticsAPI.ListTrackedMaps(System.Threading.CancellationToken)">
             <summary>
             Gets a list of maps that are tracked for the customer.
             </summary>
+            <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
             <returns>A customer map record with a list of tracked maps and their IDs.</returns>
         </member>
         <member name="T:GISBlox.Services.SDK.MapAnalytics.MapAnalyticsAPIClient">
@@ -713,36 +717,40 @@
             <param name="httpClient">The current instance of the HTTPClient class.</param>
             <param name="cache">The current instance of the MemoryCache class.</param>
         </member>
-        <member name="M:GISBlox.Services.SDK.MapAnalytics.MapAnalyticsAPIClient.GetMapEngagement(System.String,GISBlox.Services.SDK.Models.AnalyticsDateRangeEnum,System.Nullable{System.DateTime})">
+        <member name="M:GISBlox.Services.SDK.MapAnalytics.MapAnalyticsAPIClient.GetMapEngagement(System.String,GISBlox.Services.SDK.Models.AnalyticsDateRangeEnum,System.Nullable{System.DateTime},System.Threading.CancellationToken)">
             <summary>
             Gets the engagement metrics for a specific map.
             </summary>
             <param name="mapId">The ID of the map.</param>
             <param name="dateRange">The date range for the engagement data.</param>
             <param name="endDate">The end date for the engagement data (optional). If not specified, the end date will be set to yesterday.</param>
+            <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
             <returns>An engagement record for the specified map.</returns>
         </member>
-        <member name="M:GISBlox.Services.SDK.MapAnalytics.MapAnalyticsAPIClient.GetMapKpis(System.String,GISBlox.Services.SDK.Models.AnalyticsDateRangeEnum,System.Nullable{System.DateTime})">
+        <member name="M:GISBlox.Services.SDK.MapAnalytics.MapAnalyticsAPIClient.GetMapKpis(System.String,GISBlox.Services.SDK.Models.AnalyticsDateRangeEnum,System.Nullable{System.DateTime},System.Threading.CancellationToken)">
             <summary>
             Gets the KPI data for a specific map.
             </summary>
             <param name="mapId">The ID of the map.</param>
             <param name="dateRange">The date range for the KPI data.</param>
             <param name="endDate">The end date for the KPI data (optional). If not specified, the end date will be set to yesterday.</param>
+            <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
             <returns>A KPI record for the specified map.</returns>
         </member>
-        <member name="M:GISBlox.Services.SDK.MapAnalytics.MapAnalyticsAPIClient.GetMapsKpis(GISBlox.Services.SDK.Models.AnalyticsDateRangeEnum,System.Nullable{System.DateTime})">
+        <member name="M:GISBlox.Services.SDK.MapAnalytics.MapAnalyticsAPIClient.GetMapsKpis(GISBlox.Services.SDK.Models.AnalyticsDateRangeEnum,System.Nullable{System.DateTime},System.Threading.CancellationToken)">
             <summary>
             Gets the KPI data for every tracked map.
             </summary>
             <param name="dateRange">The date range for which to retrieve the KPIs.</param>
             <param name="endDate">The end date for the KPI data (optional). If not specified, the end date will be set to yesterday.</param>
+            <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
             <returns>A KPI record for each map.</returns>
         </member>
-        <member name="M:GISBlox.Services.SDK.MapAnalytics.MapAnalyticsAPIClient.ListTrackedMaps">
+        <member name="M:GISBlox.Services.SDK.MapAnalytics.MapAnalyticsAPIClient.ListTrackedMaps(System.Threading.CancellationToken)">
             <summary>
             Gets a list of maps that are tracked for the customer.
             </summary>
+            <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
             <returns>A customer map record with a list of tracked maps and their IDs.</returns>
         </member>
         <member name="T:GISBlox.Services.SDK.Models.Subscription">

--- a/GISBlox.Services.SDK/GISBlox.Services.SDK/MapAnalytics/IMapAnalyticsAPI.cs
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK/MapAnalytics/IMapAnalyticsAPI.cs
@@ -4,6 +4,7 @@
 
 using GISBlox.Services.SDK.Models;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace GISBlox.Services.SDK.MapAnalytics
@@ -19,8 +20,9 @@ namespace GISBlox.Services.SDK.MapAnalytics
       /// <param name="mapId">The ID of the map.</param>
       /// <param name="dateRange">The date range for the engagement data.</param>
       /// <param name="endDate">The end date for the engagement data (optional). If not specified, the end date will be set to yesterday.</param>
+      /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
       /// <returns>An engagement record for the specified map.</returns>
-      Task<EngagementRecord> GetMapEngagement(string mapId, AnalyticsDateRangeEnum dateRange, DateTime? endDate = null);
+      Task<EngagementRecord> GetMapEngagement(string mapId, AnalyticsDateRangeEnum dateRange, DateTime? endDate = null, CancellationToken cancellationToken = default);
 
       /// <summary>
       /// Gets the KPI data for a specific map.
@@ -28,21 +30,24 @@ namespace GISBlox.Services.SDK.MapAnalytics
       /// <param name="mapId">The ID of the map.</param>
       /// <param name="dateRange">The date range for the KPI data.</param>
       /// <param name="endDate">The end date for the KPI data (optional). If not specified, the end date will be set to yesterday.</param>
+      /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
       /// <returns>A KPI record for the specified map.</returns>
-      Task<MapKpiRecord> GetMapKpis(string mapId, AnalyticsDateRangeEnum dateRange, DateTime? endDate = null);
+      Task<MapKpiRecord> GetMapKpis(string mapId, AnalyticsDateRangeEnum dateRange, DateTime? endDate = null, CancellationToken cancellationToken = default);
 
       /// <summary>
       /// Gets the KPI data for every tracked map.
       /// </summary>
       /// <param name="dateRange">The date range for which to retrieve the KPIs.</param>
       /// <param name="endDate">The end date for the KPI data (optional). If not specified, the end date will be set to yesterday.</param>
+      /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
       /// <returns>A KPI record for each map.</returns>
-      Task<MapKpiRecord> GetMapsKpis(AnalyticsDateRangeEnum dateRange, DateTime? endDate = null);
+      Task<MapKpiRecord> GetMapsKpis(AnalyticsDateRangeEnum dateRange, DateTime? endDate = null, CancellationToken cancellationToken = default);
 
       /// <summary>
       /// Gets a list of maps that are tracked for the customer.
       /// </summary>
+      /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
       /// <returns>A customer map record with a list of tracked maps and their IDs.</returns>
-      Task<CustomerMapRecord> ListTrackedMaps();
+      Task<CustomerMapRecord> ListTrackedMaps(CancellationToken cancellationToken = default);
    }
 }

--- a/GISBlox.Services.SDK/GISBlox.Services.SDK/MapAnalytics/MapAnalyticsAPIClient.cs
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK/MapAnalytics/MapAnalyticsAPIClient.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Caching.Memory;
 using System;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace GISBlox.Services.SDK.MapAnalytics
@@ -27,15 +28,16 @@ namespace GISBlox.Services.SDK.MapAnalytics
       /// <param name="mapId">The ID of the map.</param>
       /// <param name="dateRange">The date range for the engagement data.</param>
       /// <param name="endDate">The end date for the engagement data (optional). If not specified, the end date will be set to yesterday.</param>
+      /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
       /// <returns>An engagement record for the specified map.</returns>
-      public async Task<EngagementRecord> GetMapEngagement(string mapId, AnalyticsDateRangeEnum dateRange, DateTime? endDate = null)
+      public async Task<EngagementRecord> GetMapEngagement(string mapId, AnalyticsDateRangeEnum dateRange, DateTime? endDate = null, CancellationToken cancellationToken = default)
       {
          var sb = new StringBuilder($"mapanalytics/engagement/{mapId}?range={(int)dateRange}");
          if (endDate.HasValue)
             sb.Append("&day=").Append(endDate.Value.ToString("yyyy-MM-dd"));
 
          var requestUri = sb.ToString();
-         return await HttpGet<EngagementRecord>(HttpClient, cache, requestUri);
+         return await HttpGet<EngagementRecord>(HttpClient, Cache, requestUri, null, null, cancellationToken);
       }
 
       /// <summary>
@@ -44,15 +46,16 @@ namespace GISBlox.Services.SDK.MapAnalytics
       /// <param name="mapId">The ID of the map.</param>
       /// <param name="dateRange">The date range for the KPI data.</param>
       /// <param name="endDate">The end date for the KPI data (optional). If not specified, the end date will be set to yesterday.</param>
+      /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
       /// <returns>A KPI record for the specified map.</returns>
-      public async Task<MapKpiRecord> GetMapKpis(string mapId, AnalyticsDateRangeEnum dateRange, DateTime? endDate = null)
+      public async Task<MapKpiRecord> GetMapKpis(string mapId, AnalyticsDateRangeEnum dateRange, DateTime? endDate = null, CancellationToken cancellationToken = default)
       {
          var sb = new StringBuilder($"mapanalytics/kpis/{mapId}?range={(int)dateRange}");
          if (endDate.HasValue)
             sb.Append("&day=").Append(endDate.Value.ToString("yyyy-MM-dd"));
 
          var requestUri = sb.ToString();
-         return await HttpGet<MapKpiRecord>(HttpClient, cache, requestUri);
+         return await HttpGet<MapKpiRecord>(HttpClient, Cache, requestUri, null, null, cancellationToken);
       }
 
       /// <summary>
@@ -60,25 +63,27 @@ namespace GISBlox.Services.SDK.MapAnalytics
       /// </summary>
       /// <param name="dateRange">The date range for which to retrieve the KPIs.</param>
       /// <param name="endDate">The end date for the KPI data (optional). If not specified, the end date will be set to yesterday.</param>
+      /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
       /// <returns>A KPI record for each map.</returns>
-      public async Task<MapKpiRecord> GetMapsKpis(AnalyticsDateRangeEnum dateRange, DateTime? endDate = null)
+      public async Task<MapKpiRecord> GetMapsKpis(AnalyticsDateRangeEnum dateRange, DateTime? endDate = null, CancellationToken cancellationToken = default)
       {
          var sb = new StringBuilder($"mapanalytics/kpis?range={(int)dateRange}");
          if (endDate.HasValue)
             sb.Append("&day=").Append(endDate.Value.ToString("yyyy-MM-dd"));
 
          var requestUri = sb.ToString();
-         return await HttpGet<MapKpiRecord>(HttpClient, cache, requestUri);
+         return await HttpGet<MapKpiRecord>(HttpClient, Cache, requestUri, null, null, cancellationToken);
       }
 
       /// <summary>
       /// Gets a list of maps that are tracked for the customer.
       /// </summary>
+      /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
       /// <returns>A customer map record with a list of tracked maps and their IDs.</returns>
-      public async Task<CustomerMapRecord> ListTrackedMaps()
+      public async Task<CustomerMapRecord> ListTrackedMaps(CancellationToken cancellationToken = default)
       {
          const string requestUri = "mapanalytics/list";
-         return await HttpGet<CustomerMapRecord>(HttpClient, cache, requestUri);
+         return await HttpGet<CustomerMapRecord>(HttpClient, Cache, requestUri, null, null, cancellationToken);
       }
    }
 }

--- a/GISBlox.Services.SDK/GISBlox.Services.SDK/PostalCodes/AreaCodeHelper.cs
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK/PostalCodes/AreaCodeHelper.cs
@@ -20,7 +20,7 @@ namespace GISBlox.Services.SDK.PostalCodes
    /// </remarks>
    /// <param name="httpClient">The current instance of the HTTPClient class.</param>
    /// <param name="cache">The current instance of the MemoryCache class.</param>
-   public class AreaCodeHelper(HttpClient httpClient, IMemoryCache cache) : ApiClient(httpClient, cache)
+   public class AreaCodeHelper(HttpClient httpClient, IMemoryCache cache) : ApiClient(httpClient, cache), IAreaCodeHelper
    {
       /// <summary>
       /// Query for a specific gemeente.


### PR DESCRIPTION
#### PR Summary  
Added `CancellationToken` support to `MapAnalyticsAPI` methods to enable cancellation of asynchronous operations and updated related tests, documentation, and versioning.  
- **`MapAnalyticsAPIClient.cs`**: Added `CancellationToken` parameter to methods and updated `HttpGet` calls.  
- **`IMapAnalyticsAPI.cs`**: Updated method signatures to include optional `CancellationToken` parameter.  
- **`MapAnalyticsTests.cs`**: Updated test methods to pass `CancellationToken.None`.  
- **`GISBlox.Services.SDK.xml`**: Updated XML documentation to reflect `CancellationToken` changes.  
- **`GISBlox.Services.SDK.csproj`**: Incremented version from `2.6.0` to `2.6.1`.  
