### PR TITLE
Handle 204 No Content in API client, update tests

### DIFF
--- a/GISBlox.Services.SDK/GISBlox.Services.SDK.Tests/InfoTests.cs
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK.Tests/InfoTests.cs
@@ -4,6 +4,7 @@
    public class InfoTests
    {
       const string BASE_URL = "https://services.gisblox.com";
+      const int API_QUOTA_DELAY = 5000;  // Allows to run all tests together without exceeding API call quota
 
       [TestMethod]
       public async Task GetSubscriptionInfo()
@@ -19,6 +20,8 @@
             
             Assert.AreNotEqual(0, subscriptions.Count);
          }
+
+         await Task.Delay(API_QUOTA_DELAY, CancellationToken.None);
       }
 
       [TestMethod]
@@ -32,6 +35,8 @@
          {
             List<Subscription> subscriptions = await client.Info.GetSubscriptions(CancellationToken.None);
             subscriptions.ForEach(sub => Console.WriteLine($"\r\nName: {sub.Name} \r\nDescription: {sub.Description} \r\nRegistration date: {sub.RegisterDate} Expiration date: {sub.ExpirationDate} Expired: {sub.Expired}"));
+
+            await Task.Delay(API_QUOTA_DELAY, CancellationToken.None);
 
             List<Subscription> subscriptionsCached = await client.Info.GetSubscriptions(CancellationToken.None);
             Assert.HasCount(subscriptions.Count, subscriptionsCached);

--- a/GISBlox.Services.SDK/GISBlox.Services.SDK.Tests/PostalCodesTest.cs
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK.Tests/PostalCodesTest.cs
@@ -38,7 +38,7 @@
          Assert.IsNotNull(record, "Response is empty.");
          
          PostalCode4 pc = record.PostalCode[0];
-         Assert.IsTrue(pc.Location.Gemeente == "Amersfoort" && pc.Location.Geometry.Centroid == "POINT (155029.15793771204 463047.87594218826)");
+         Assert.IsTrue(pc.Location.Gemeente == "Amersfoort" && pc.Location.Geometry.Centroid == "POINT (155029 463048)");
 
          await Task.Delay(API_QUOTA_DELAY, CancellationToken.None);
       }
@@ -52,7 +52,7 @@
          Assert.IsNotNull(record, "Response is empty.");
 
          PostalCode4 pc = record.PostalCode[0];
-         Assert.IsTrue(pc.Location.Gemeente == "Amersfoort" && pc.Location.Geometry.Centroid == "POINT (155029.15793771204 463047.87594218826)");
+         Assert.IsTrue(pc.Location.Gemeente == "Amersfoort" && pc.Location.Geometry.Centroid == "POINT (155029 463048)");
 
          PostalCode4Record recordCached = await _client.PostalCodes.GetPostalCodeRecord<PostalCode4Record>(id, CoordinateSystem.RDNew, CancellationToken.None);
          
@@ -190,7 +190,7 @@
          Assert.IsNotNull(record, "Response is empty.");
 
          PostalCode6 pc = record.PostalCode[0];
-         Assert.IsTrue(pc.Location.Gemeente == "Amersfoort" && pc.Location.Geometry.Centroid == "POINT (155155.51254284632 463159.828901163)");
+         Assert.IsTrue(pc.Location.Gemeente == "Amersfoort" && pc.Location.Geometry.Centroid == "POINT (155156 463160)");
 
          await Task.Delay(API_QUOTA_DELAY, CancellationToken.None);
       }

--- a/GISBlox.Services.SDK/GISBlox.Services.SDK.Tests/ProjectionTests.cs
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK.Tests/ProjectionTests.cs
@@ -4,8 +4,7 @@
    public class ProjectionTests
    {
       GISBloxClient _client;
-      const string BASE_URL = "https://services.gisblox.com";
-      const int API_QUOTA_DELAY = 2500;  // Allows to run all tests together without exceeding API call quota
+      const string BASE_URL = "https://services.gisblox.com";      
 
       #region Initialization and cleanup
 
@@ -46,9 +45,7 @@
          Location location = await _client.Projection.ToRDSComplete(coord, CancellationToken.None);
 
          Assert.IsNotNull(location, "Response is empty.");
-         Assert.IsTrue(location.X == 85530 && location.Y == 446100 && location.Lat == 51.998929 && location.Lon == 4.375587);
-
-         await Task.Delay(API_QUOTA_DELAY, CancellationToken.None);
+         Assert.IsTrue(location.X == 85530 && location.Y == 446100 && location.Lat == 51.998929 && location.Lon == 4.375587);         
       }
 
       [TestMethod]
@@ -65,9 +62,7 @@
          Assert.IsNotNull(rdPoints.Count != 0, "Response is empty.");
          Assert.IsTrue(rdPoints[0].X == 85530 && rdPoints[0].Y == 446100);
          Assert.IsTrue(rdPoints[1].X == 75483 && rdPoints[1].Y == 568787);
-         Assert.IsTrue(rdPoints[2].X == 82197 && rdPoints[2].Y == 569794);
-
-         await Task.Delay(API_QUOTA_DELAY * 2, CancellationToken.None);
+         Assert.IsTrue(rdPoints[2].X == 82197 && rdPoints[2].Y == 569794);         
       }
 
       [TestMethod]
@@ -84,9 +79,7 @@
          Assert.IsNotNull(loc.Count != 0, "Response is empty.");
          Assert.IsTrue(loc[0].X == 85530 && loc[0].Y == 446100 && loc[0].Lat == 51.998929 && loc[0].Lon == 4.375587);
          Assert.IsTrue(loc[1].X == 75483 && loc[1].Y == 568787 && loc[1].Lat == 53.1 && loc[1].Lon == 4.2);
-         Assert.IsTrue(loc[2].X == 82197 && loc[2].Y == 569794 && loc[2].Lat == 53.11 && loc[2].Lon == 4.3);
-
-         await Task.Delay(API_QUOTA_DELAY, CancellationToken.None);
+         Assert.IsTrue(loc[2].X == 82197 && loc[2].Y == 569794 && loc[2].Lat == 53.11 && loc[2].Lon == 4.3);         
       }
 
       #endregion
@@ -111,8 +104,6 @@
 
          Assert.IsNotNull(location, "Response is empty.");
          Assert.IsTrue(location.Lat == 51.998927449317591 && location.Lon == 4.3755841993518345 && location.X == 85530 && location.Y == 446100);
-
-         await Task.Delay(API_QUOTA_DELAY, CancellationToken.None);
       }
 
       [TestMethod]
@@ -128,10 +119,8 @@
 
          Assert.IsNotNull(coords.Count != 0, "Response is empty.");
          Assert.IsTrue(coords[0].Lat == 52.9791861737104 && coords[0].Lon == 4.56833613045079);
-         Assert.IsTrue(coords[1].Lat == 0 && coords[1].Lon == 0);
+         Assert.IsNull(coords[1]);
          Assert.IsTrue(coords[2].Lat == 52.93526683092437 && coords[2].Lon == 4.7327735938900535);
-
-         await Task.Delay(API_QUOTA_DELAY * 2, CancellationToken.None);
       }
 
       [TestMethod]

--- a/GISBlox.Services.SDK/GISBlox.Services.SDK/ApiClient.cs
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK/ApiClient.cs
@@ -147,6 +147,11 @@ namespace GISBlox.Services.SDK
 
          await EnsureSuccessStatusCodeAsync(response, cancellationToken);
 
+         if (response.StatusCode == System.Net.HttpStatusCode.NoContent)
+         {
+            return default;
+         }
+
          return await response.Content.ReadFromJsonAsync<TResult>(JsonSerializerOptions, cancellationToken).ConfigureAwait(false);
       }
 
@@ -243,6 +248,11 @@ namespace GISBlox.Services.SDK
 
          await EnsureSuccessStatusCodeAsync(response, cancellationToken);
 
+         if (response.StatusCode == System.Net.HttpStatusCode.NoContent)
+         {
+            return default;
+         }
+
          return await response.Content.ReadFromJsonAsync<TResult>(JsonSerializerOptions, cancellationToken).ConfigureAwait(false);
       }
 
@@ -327,6 +337,11 @@ namespace GISBlox.Services.SDK
          using var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
          await EnsureSuccessStatusCodeAsync(response, cancellationToken);
+
+         if (response.StatusCode == System.Net.HttpStatusCode.NoContent)
+         {
+            return default;
+         }
 
          return await response.Content.ReadFromJsonAsync<TResult>(JsonSerializerOptions, cancellationToken).ConfigureAwait(false);
       }

--- a/GISBlox.Services.SDK/GISBlox.Services.SDK/GISBlox.Services.SDK.csproj
+++ b/GISBlox.Services.SDK/GISBlox.Services.SDK/GISBlox.Services.SDK.csproj
@@ -9,7 +9,7 @@
     <RepositoryUrl>https://github.com/GISBlox/gisblox-services-sdk</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>GISBlox</PackageTags>
-    <Version>2.6.1</Version>
+    <Version>2.6.2</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>Key.snk.pfx</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
Handle 204 No Content in API client, update tests

API client methods now return default for 204 No Content responses instead of deserializing empty bodies. Test assertions were updated for new expected values, including rounded centroid coordinates and null checks. Improved API quota delay handling in InfoTests and removed unnecessary delays from ProjectionTests. Bumped version to 2.6.2.